### PR TITLE
Handle missing tally data gracefully

### DIFF
--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -1,0 +1,15 @@
+import tempfile, os, sys
+
+# Ensure project root is on path so He3_Plotter can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from He3_Plotter import process_simulation_file
+
+def test_process_simulation_file_no_tally():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        tmp.write(b"no tally data\n")
+        tmp.close()
+        result = process_simulation_file(tmp.name, area=1.0, volume=1.0, neutron_yield=1.0)
+        assert result is None
+    finally:
+        os.unlink(tmp.name)


### PR DESCRIPTION
## Summary
- Avoid unpacking errors in `read_tally_blocks_to_df` when required tallies are missing by returning empty DataFrames
- Add regression test for processing files without tally data

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689c92a66ecc83248905bc063d314a5b