### PR TITLE
Clarify ctme extraction behaviour

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -103,11 +103,14 @@ MCNP_EXECUTABLE = os.path.join(base_path, "MCNP_CODE", "bin", "mcnp6")
 
 def extract_ctme_minutes(file_path):
     """
-    Extract the 'ctme' value (in minutes) from the last line of the file.
+    Search the file for the most recent ``ctme`` value (in minutes).
+    The file is scanned from the end backwards to locate the last
+    occurrence rather than assuming it appears on the final line.
     """
     try:
         with open(file_path, 'r') as f:
             lines = f.readlines()
+            # Search in reverse order to find the last ctme quickly
             for line in reversed(lines):
                 match = re.search(r"\bctme\s+(\d+(\.\d+)?)", line, re.IGNORECASE)
                 if match:


### PR DESCRIPTION
## Summary
- Update `extract_ctme_minutes` docstring to clarify it scans backwards for the last `ctme`
- Add inline comment explaining reverse search strategy

## Testing
- `pytest tests/test_he3_plotter.py -q`
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689c976ccc808324b74f8c9e9e58e21d