### PR TITLE
refactor: centralize output handling

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -43,7 +43,7 @@ def check_existing_outputs(inp_files, folder):
         folder = os.path.expanduser(os.path.join("~/Documents/PhD/MCNP/MY_MCNP", folder))
     existing_outputs = []
     for inp in inp_files:
-        base = os.path.splitext(inp)[0]
+        base = os.path.basename(inp)
         for suffix in ("o", "r", "c"):
             out_name = os.path.join(folder, f"{base}{suffix}")
             if os.path.exists(out_name):


### PR DESCRIPTION
## Summary
- centralize handling of existing output files with suffixes `o`, `r`, or `c` in `_handle_existing_outputs`
- use shared helper in geometry plotter and single-file ixr paths
- detect suffix-only output files without assuming a preceding dot

## Testing
- `MPLBACKEND=Agg pytest tests/test_he3_plotter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f112e90c8832487d294293087b8dc