### PR TITLE
Fix file dialog positioning to prevent off-screen placement

### DIFF
--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -30,13 +30,26 @@ def _get_hidden_root():
 
 
 def select_file(title="Select a file"):
-    root = _get_hidden_root()
-    return askopenfilename(title=title, parent=root)
+    """Prompt the user to select a single file.
+
+    Passing the hidden root as the dialog's parent caused the dialog window to
+    be positioned relative to that (1×1, off‑screen) root on some systems,
+    making it appear partially off screen and immovable.  Instead we just
+    initialise Tk to ensure the Tk subsystem is ready and let the operating
+    system place the dialog normally so it can be moved by the user.
+    """
+    _get_hidden_root()  # Ensure Tk is initialised
+    return askopenfilename(title=title)
 
 
 def select_folder(title="Select a folder"):
-    root = _get_hidden_root()
-    return askdirectory(title=title, parent=root)
+    """Prompt the user to select a folder.
+
+    See :func:`select_file` for an explanation of why the dialog is not given a
+    parent window.
+    """
+    _get_hidden_root()
+    return askdirectory(title=title)
 
 def make_plot_dir(base_path):
     plot_dir = os.path.join(base_path, "plots")


### PR DESCRIPTION
## Summary
- Avoid anchoring file/folder dialogs to the hidden Tk root so dialogs open centered and are movable.
- Document reasoning for dialog behaviour in helper functions.

## Testing
- `pytest tests/test_he3_plotter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f25e5e3c48324a40caf781e7ae8cd