### PR TITLE
Remove unused context_lines parameter from tally parser

### DIFF
--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -69,7 +69,7 @@ def process_simulation_file(file_path, area, volume, neutron_yield):
     return calculate_rates(df_neutron, area, volume, neutron_yield)
 
 # ---- Function to read MCNP tally blocks and convert to DataFrame ----
-def read_tally_blocks_to_df(file_path, tally_ids=("14", "24", "34"), context_lines=30):
+def read_tally_blocks_to_df(file_path, tally_ids=("14", "24", "34")):
     with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
         lines = f.readlines()
 

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -2,7 +2,7 @@ import tempfile, os, sys
 
 # Ensure project root is on path so He3_Plotter can be imported
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from He3_Plotter import process_simulation_file
+from He3_Plotter import process_simulation_file, read_tally_blocks_to_df
 
 def test_process_simulation_file_no_tally():
     tmp = tempfile.NamedTemporaryFile(delete=False)
@@ -11,5 +11,39 @@ def test_process_simulation_file_no_tally():
         tmp.close()
         result = process_simulation_file(tmp.name, area=1.0, volume=1.0, neutron_yield=1.0)
         assert result is None
+    finally:
+        os.unlink(tmp.name)
+
+
+def test_read_tally_blocks_to_df_parses_data():
+    content = """
+1tally    14
+something
+energy value error
+0.1 2.0 0.1
+0.2 3.0 0.2
+total
+1tally    24
+something
+energy value error
+0.1 1.0 0.05
+0.2 2.0 0.1
+total
+1tally    34
+something
+energy value error
+0.5 5.0 0.5
+total
+"""
+    tmp = tempfile.NamedTemporaryFile("w", delete=False)
+    try:
+        tmp.write(content)
+        tmp.close()
+        df_neutron, df_photon = read_tally_blocks_to_df(tmp.name)
+        assert list(df_neutron["energy"]) == [0.1, 0.2]
+        assert list(df_neutron["neutrons_incident_cm2"]) == [2.0, 3.0]
+        assert list(df_neutron["neutrons_detected_cm2"]) == [1.0, 2.0]
+        assert list(df_photon["photon_energy"]) == [0.5]
+        assert list(df_photon["photons"]) == [5.0]
     finally:
         os.unlink(tmp.name)


### PR DESCRIPTION
## Summary
- Drop unused `context_lines` argument from `read_tally_blocks_to_df`
- Add test verifying neutron and photon tally parsing

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689f396342988324879270fc197c8691