### PR TITLE
Allow configuring base directory via environment variable

### DIFF
--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -50,6 +50,15 @@ CSV Output (if enabled)
 • Type 4: photon tally energy spectrum.
 
 ========================
+Configuration
+========================
+MCNP Tools looks for the base directory of your MCNP installation when
+constructing paths. You can specify this location by setting the
+``MCNP_BASE_DIR`` environment variable or by creating a
+``~/.mcnp_tools_settings.json`` file with a ``"MY_MCNP_PATH"`` entry. If
+neither is provided, your home directory is used by default.
+
+========================
 About & Support
 ========================
 Developer: Ioan Hughes

--- a/run_packages.py
+++ b/run_packages.py
@@ -10,14 +10,14 @@ import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 from tkinter import Tk
 from tkinter.filedialog import askdirectory, askopenfilename
 
 logger = logging.getLogger(__name__)
 
 # Dynamically load MCNP6 base path from user settings
-SETTINGS_PATH = os.path.join(os.path.expanduser("~"), ".mcnp_tools_settings.json")
-DEFAULT_BASE_DIR = "/Users/ioanhughes/Documents/PhD/MCNP/MY_MCNP"
+SETTINGS_PATH = os.path.join(Path.home(), ".mcnp_tools_settings.json")
 
 try:
     with open(SETTINGS_PATH, "r") as f:
@@ -26,7 +26,9 @@ except Exception:
     settings = {}
 
 # Centralised base directory used for all path construction
-BASE_DIR = os.path.expanduser(settings.get("MY_MCNP_PATH", DEFAULT_BASE_DIR))
+env_base_dir = os.getenv("MCNP_BASE_DIR")
+settings_base_dir = settings.get("MY_MCNP_PATH")
+BASE_DIR = os.path.expanduser(env_base_dir or settings_base_dir or str(Path.home()))
 
 
 def resolve_path(path: str) -> str:


### PR DESCRIPTION
## Summary
- Read MCNP base directory from `MCNP_BASE_DIR` or `MY_MCNP_PATH` settings, with `Path.home()` fallback
- Document how to configure the base directory via environment variable or settings file

## Testing
- `pytest tests/test_he3_plotter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f415f0ec483249dc652f86c6dc29d