### PR TITLE
Honor MY_MCNP environment variable for MCNP executable

### DIFF
--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -54,7 +54,7 @@ Configuration
 ========================
 MCNP Tools looks for the base directory of your MCNP installation when
 constructing paths. You can specify this location by setting the
-``MCNP_BASE_DIR`` environment variable or by creating a
+``MCNP_BASE_DIR`` or ``MY_MCNP`` environment variable or by creating a
 ``~/.mcnp_tools_settings.json`` file with a ``"MY_MCNP_PATH"`` entry. If
 neither is provided, your home directory is used by default.
 

--- a/run_packages.py
+++ b/run_packages.py
@@ -25,8 +25,11 @@ try:
 except Exception:
     settings = {}
 
-# Centralised base directory used for all path construction
-env_base_dir = os.getenv("MCNP_BASE_DIR")
+# Centralised base directory used for all path construction. Priority is given
+# to environment variables so installations can be relocated without editing
+# configuration files. ``MY_MCNP`` mirrors the variable commonly set by the
+# MCNP installation scripts.
+env_base_dir = os.getenv("MCNP_BASE_DIR") or os.getenv("MY_MCNP")
 settings_base_dir = settings.get("MY_MCNP_PATH")
 BASE_DIR = os.path.expanduser(env_base_dir or settings_base_dir or str(Path.home()))
 
@@ -36,7 +39,11 @@ def resolve_path(path: str) -> str:
     return path if os.path.isabs(path) else os.path.join(BASE_DIR, path)
 
 
-MCNP_EXECUTABLE = os.path.join(BASE_DIR, "MCNP_CODE", "bin", "mcnp6")
+# Allow the MCNP executable to be located via the ``MY_MCNP`` environment
+# variable, falling back to ``BASE_DIR`` if it is not set.
+MCNP_EXECUTABLE = os.path.join(
+    os.getenv("MY_MCNP", BASE_DIR), "MCNP_CODE", "bin", "mcnp6"
+)
 
 
 def calculate_estimated_time(ctme_minutes, num_files, jobs):


### PR DESCRIPTION
## Summary
- Allow base directory to be configured via `MY_MCNP` env var
- Mention `MY_MCNP` in configuration documentation

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a32d2811148324a60378ac58289262