### PR TITLE
Handle MCNP input files without tally data

### DIFF
--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -272,6 +272,11 @@ def run_analysis_type_2(folder_path, lab_data_path, area, volume, neutron_yield,
     experimental_df.columns = experimental_df.columns.str.strip()
     results = []
     for filename in os.listdir(folder_path):
+        # MCNP output files append an "o" to the end of the input filename.
+        # Skip any files that do not follow this convention to avoid
+        # processing the input decks themselves which contain no tally data.
+        if not filename.endswith("o"):
+            continue
         file_path = os.path.join(folder_path, filename)
         if os.path.isfile(file_path):
             thickness = parse_thickness_from_filename(filename)
@@ -334,6 +339,9 @@ def run_analysis_type_3(folder_path, area, volume, neutron_yield, export_csv=Tru
     exp_err = EXP_ERR
     results = []
     for filename in os.listdir(folder_path):
+        # Only process MCNP output files, which end with "o"
+        if not filename.endswith("o"):
+            continue
         file_path = os.path.join(folder_path, filename)
         if os.path.isfile(file_path):
             match = re.search(r'([-+]?\d+_\d+|\d+)', filename)

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -2,7 +2,11 @@ import tempfile, os, sys
 
 # Ensure project root is on path so He3_Plotter can be imported
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from He3_Plotter import process_simulation_file, read_tally_blocks_to_df
+from He3_Plotter import (
+    process_simulation_file,
+    read_tally_blocks_to_df,
+    run_analysis_type_3,
+)
 
 def test_process_simulation_file_no_tally():
     tmp = tempfile.NamedTemporaryFile(delete=False)
@@ -47,3 +51,32 @@ total
         assert list(df_photon["photons"]) == [5.0]
     finally:
         os.unlink(tmp.name)
+
+
+def test_run_analysis_type_3_ignores_non_output_files(tmp_path):
+    """run_analysis_type_3 should ignore files that do not end with 'o'."""
+    folder = tmp_path / "sim"
+    folder.mkdir()
+
+    # Create input files without tally data and corresponding output files
+    (folder / "0_0").write_text("no tally data\n")
+    (folder / "1_0").write_text("no tally data\n")
+    (folder / "2_0").write_text("no tally data\n")
+    content = (
+        "1tally    14\nenergy value error\n0.1 2.0 0.1\n0.2 3.0 0.2\ntotal\n"
+        "1tally    24\nenergy value error\n0.1 1.0 0.05\n0.2 2.0 0.1\ntotal\n"
+    )
+    (folder / "0_0o").write_text(content)
+    (folder / "1_0o").write_text(content)
+    (folder / "2_0o").write_text(content)
+
+    run_analysis_type_3(str(folder), area=1.0, volume=1.0, neutron_yield=1.0)
+
+    csv_dir = folder / "csvs"
+    csv_files = list(csv_dir.glob("*.csv"))
+    assert len(csv_files) == 1, "Expected exactly one CSV output file"
+    import pandas as pd
+
+    df = pd.read_csv(csv_files[0])
+    # Only the output files should have been processed
+    assert len(df) == 3


### PR DESCRIPTION
## Summary
- Skip MCNP input decks without tally data by only processing files ending in `o`
- Cover source displacement analysis with tests to ensure only output files are parsed

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33447cb148324a4c5d3408f17b70b