### PR TITLE
Handle optional 'cm' in thickness filenames

### DIFF
--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -195,7 +195,13 @@ def calculate_chi_squared(obs, exp, obs_err, exp_err):
 
 # ---- Function to extract moderator thickness from filename ----
 def parse_thickness_from_filename(filename):
-    match = re.search(r'_(\d+)cmo', filename)
+    """Return the moderator thickness parsed from the filename.
+
+    Accepts filenames ending in either ``"_10cmo"`` or the shortened
+    ``"_10o"`` format.  The optional ``"cm"`` substring is handled by the
+    regular expression so both conventions are supported.
+    """
+    match = re.search(r'_(\d+)(?:cm)?o$', filename)
     return int(match.group(1)) if match else None
 
 # ---- Define constants ----

--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -37,7 +37,7 @@ Analysing Results
 • Saved plots will appear below and in the 'plots' folder.
 
 File Naming Tips:
-• Thickness Comparison: use endings like '_10cmo', '_5cmo'.
+• Thickness Comparison: use endings like '_10cmo', '_5cmo', or the shorter '_10o'.
 • Source Alignment: use displacement-style names like '5_0cm'.
 
 ========================

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -6,7 +6,13 @@ from He3_Plotter import (
     process_simulation_file,
     read_tally_blocks_to_df,
     run_analysis_type_3,
+    parse_thickness_from_filename,
 )
+
+def test_parse_thickness_from_filename_handles_optional_cm():
+    assert parse_thickness_from_filename("example_10cmo") == 10
+    assert parse_thickness_from_filename("example_10o") == 10
+    assert parse_thickness_from_filename("example_o") is None
 
 def test_process_simulation_file_no_tally():
     tmp = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
## Summary
- Allow parsing filenames ending in either `_10cmo` or `_10o`
- Document optional `cm` segment and add tests for both formats
- Limit pytest discovery to repo's test suite only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a452c99cc48324b6d1c22f23fa4815