### PR TITLE
Allow tagging of analysis outputs

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -90,6 +90,7 @@ class He3PlotterApp:
                 self.save_csv_var = tk.BooleanVar(value=settings.get("save_csv", True))
                 self.neutron_yield = tk.StringVar(value=settings.get("neutron_yield", "single"))
                 self.theme_var = tk.StringVar(value=settings.get("theme", "flatly"))
+                self.file_tag_var = tk.StringVar(value=settings.get("file_tag", ""))
             except Exception:
                 self.default_jobs_var = tk.IntVar(value=3)
                 self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -97,6 +98,7 @@ class He3PlotterApp:
                 self.save_csv_var = tk.BooleanVar(value=True)
                 self.neutron_yield = tk.StringVar(value="single")
                 self.theme_var = tk.StringVar(value="flatly")
+                self.file_tag_var = tk.StringVar(value="")
         else:
             self.default_jobs_var = tk.IntVar(value=3)
             self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -104,6 +106,7 @@ class He3PlotterApp:
             self.save_csv_var = tk.BooleanVar(value=True)
             self.neutron_yield = tk.StringVar(value="single")
             self.theme_var = tk.StringVar(value="flatly")
+            self.file_tag_var = tk.StringVar(value="")
 
         # Shared variables for runner view
         self.mcnp_folder_var = tk.StringVar()

--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -14,6 +14,9 @@ import atexit
 
 logger = logging.getLogger(__name__)
 
+# Global tag appended to output filenames; configurable via set_filename_tag
+FILENAME_TAG = ""
+
 # ---- Utility Functions ----
 _hidden_root = None
 
@@ -54,12 +57,33 @@ def make_plot_dir(base_path):
     os.makedirs(plot_dir, exist_ok=True)
     return plot_dir
 
+
+def set_filename_tag(tag: str) -> None:
+    """Configure a tag to be appended to output filenames.
+
+    Parameters
+    ----------
+    tag:
+        Arbitrary text entered by the user to help differentiate analyses. It
+        will be inserted into output filenames by :func:`get_output_path`.
+    """
+
+    global FILENAME_TAG
+    FILENAME_TAG = tag.strip()
+
 # Utility to get output path and ensure directory exists
 def get_output_path(base_path, filename_prefix, descriptor, extension="pdf", subfolder="plots"):
+    """Return a filesystem path for saving output files.
+
+    Any user-provided :data:`FILENAME_TAG` is inserted before the date to help
+    differentiate saved plots and CSVs.
+    """
+
     output_dir = os.path.join(base_path, subfolder)
     os.makedirs(output_dir, exist_ok=True)
     date_str = datetime.now().strftime("%Y-%m-%d")
-    filename = f"{filename_prefix} {descriptor} {date_str}.{extension}"
+    tag = f" {FILENAME_TAG.strip()}" if FILENAME_TAG.strip() else ""
+    filename = f"{filename_prefix} {descriptor}{tag} {date_str}.{extension}"
     return os.path.join(output_dir, filename)
 
 def process_simulation_file(file_path, area, volume, neutron_yield):

--- a/analysis_view.py
+++ b/analysis_view.py
@@ -79,6 +79,12 @@ class AnalysisView:
         )
         self.analysis_combobox.pack(padx=10, pady=5)
         self.analysis_combobox.bind("<<ComboboxSelected>>", self.update_analysis_type)
+        tag_frame = ttk.Frame(self.frame)
+        tag_frame.pack(fill="x", padx=10, pady=5)
+        ttk.Label(tag_frame, text="File tag:").pack(side="left")
+        ttk.Entry(tag_frame, textvariable=self.app.file_tag_var, width=25).pack(
+            side="left", padx=5
+        )
 
         button_frame = ttk.Frame(self.frame)
         button_frame.pack(pady=10)
@@ -118,6 +124,7 @@ class AnalysisView:
                 "jobs": self.app.mcnp_jobs_var.get(),
                 "folder": self.app.mcnp_folder_var.get(),
             },
+            "file_tag": self.app.file_tag_var.get(),
         }
         try:
             with open(CONFIG_FILE, "w") as f:
@@ -147,6 +154,7 @@ class AnalysisView:
                     run_profile = config.get("run_profile", {})
                     self.app.mcnp_jobs_var.set(run_profile.get("jobs", 3))
                     self.app.mcnp_folder_var.set(run_profile.get("folder", ""))
+                    self.app.file_tag_var.set(config.get("file_tag", ""))
             except Exception as e:
                 self.app.log(f"Failed to load config: {e}", logging.ERROR)
 
@@ -261,6 +269,7 @@ class AnalysisView:
     def process_analysis(self, args):
         self.save_config()
         export_csv = self.app.save_csv_var.get()
+        He3_Plotter.set_filename_tag(self.app.file_tag_var.get())
         try:
             if args[0] == AnalysisType.EFFICIENCY_NEUTRON_RATES:
                 _, file_path, yield_value = args

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -8,6 +8,8 @@ from He3_Plotter import (
     run_analysis_type_3,
     parse_thickness_from_filename,
     run_analysis_type_2,
+    get_output_path,
+    set_filename_tag,
 )
 
 def test_parse_thickness_from_filename_handles_optional_cm():
@@ -147,3 +149,10 @@ def test_run_analysis_type_2_multiple_folders_without_lab_data(tmp_path):
         "simulated_error",
         "dataset",
     ]
+
+
+def test_get_output_path_includes_tag(tmp_path):
+    set_filename_tag("experiment")
+    path = get_output_path(tmp_path, "base", "desc")
+    set_filename_tag("")
+    assert "experiment" in os.path.basename(path)


### PR DESCRIPTION
## Summary
- Add optional file tag field on analysis tab to differentiate saved plots and CSVs
- Persist tag in config and propagate to filename generation
- Provide utility and tests for tagged output paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58a1bbe0483249a8ad82e8039015b