### PR TITLE
Add configurable plot file type selection

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -91,6 +91,7 @@ class He3PlotterApp:
                 self.neutron_yield = tk.StringVar(value=settings.get("neutron_yield", "single"))
                 self.theme_var = tk.StringVar(value=settings.get("theme", "flatly"))
                 self.file_tag_var = tk.StringVar(value=settings.get("file_tag", ""))
+                self.plot_ext_var = tk.StringVar(value=settings.get("plot_ext", "pdf"))
             except Exception:
                 self.default_jobs_var = tk.IntVar(value=3)
                 self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -99,6 +100,7 @@ class He3PlotterApp:
                 self.neutron_yield = tk.StringVar(value="single")
                 self.theme_var = tk.StringVar(value="flatly")
                 self.file_tag_var = tk.StringVar(value="")
+                self.plot_ext_var = tk.StringVar(value="pdf")
         else:
             self.default_jobs_var = tk.IntVar(value=3)
             self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -107,6 +109,7 @@ class He3PlotterApp:
             self.neutron_yield = tk.StringVar(value="single")
             self.theme_var = tk.StringVar(value="flatly")
             self.file_tag_var = tk.StringVar(value="")
+            self.plot_ext_var = tk.StringVar(value="pdf")
 
         # Shared variables for runner view
         self.mcnp_folder_var = tk.StringVar()

--- a/He3_Plotter.py
+++ b/He3_Plotter.py
@@ -17,6 +17,10 @@ logger = logging.getLogger(__name__)
 # Global tag appended to output filenames; configurable via set_filename_tag
 FILENAME_TAG = ""
 
+# Default extension used when saving plot images; configurable via
+# :func:`set_plot_extension`.
+PLOT_EXTENSION = "pdf"
+
 # ---- Utility Functions ----
 _hidden_root = None
 
@@ -70,6 +74,20 @@ def set_filename_tag(tag: str) -> None:
 
     global FILENAME_TAG
     FILENAME_TAG = tag.strip()
+
+def set_plot_extension(extension: str) -> None:
+    """Configure the file extension used for saved plot images.
+
+    Parameters
+    ----------
+    extension:
+        Desired file extension (e.g. ``"pdf"``, ``"png"``).  If an empty
+        string is provided, the default ``"pdf"`` is used.
+    """
+
+    global PLOT_EXTENSION
+    ext = extension.strip().lower()
+    PLOT_EXTENSION = ext if ext else "pdf"
 
 # Utility to get output path and ensure directory exists
 def get_output_path(base_path, filename_prefix, descriptor, extension="pdf", subfolder="plots"):
@@ -176,7 +194,9 @@ def plot_efficiency_and_rates(df, filename):
     plt.grid(True)
     plt.semilogx()
     plt.tight_layout()
-    rate_path = get_output_path(base_dir, base_name, "Neutron rate plot", extension="pdf", subfolder="plots")
+    rate_path = get_output_path(
+        base_dir, base_name, "Neutron rate plot", extension=PLOT_EXTENSION, subfolder="plots"
+    )
     plt.savefig(rate_path)
     plt.close()
     logger.info(f"Saved: {rate_path}")
@@ -189,7 +209,9 @@ def plot_efficiency_and_rates(df, filename):
     plt.grid(True)
     plt.semilogx()
     plt.tight_layout()
-    eff_path = get_output_path(base_dir, base_name, "efficiency curve", extension="pdf", subfolder="plots")
+    eff_path = get_output_path(
+        base_dir, base_name, "efficiency curve", extension=PLOT_EXTENSION, subfolder="plots"
+    )
     plt.savefig(eff_path)
     plt.close()
     logger.info(f"Saved: {eff_path}")
@@ -432,7 +454,7 @@ def run_analysis_type_2(
 
     base_dir = os.path.commonpath(folder_paths)
     save_path = get_output_path(
-        base_dir, 'multi_thickness', 'comparison plot', extension='pdf', subfolder='plots'
+        base_dir, 'multi_thickness', 'comparison plot', extension=PLOT_EXTENSION, subfolder='plots'
     )
     plt.savefig(save_path)
     plt.close()
@@ -526,7 +548,9 @@ def run_analysis_type_3(folder_path, area, volume, neutron_yield, export_csv=Tru
         horizontalalignment='right',
         bbox=dict(facecolor='white', alpha=0.6, edgecolor='none')
     )
-    save_path = get_output_path(folder_path, folder_name, "source shift plot", extension="pdf", subfolder="plots")
+    save_path = get_output_path(
+        folder_path, folder_name, "source shift plot", extension=PLOT_EXTENSION, subfolder="plots"
+    )
     plt.savefig(save_path)
     plt.close()
     logger.info(f"Saved: {save_path}")
@@ -557,7 +581,9 @@ def run_analysis_type_4(file_path, export_csv=True):
     plt.legend()
     plt.tight_layout()
 
-    save_path = get_output_path(base_dir, base_name, "photon tally plot", extension="pdf", subfolder="plots")
+    save_path = get_output_path(
+        base_dir, base_name, "photon tally plot", extension=PLOT_EXTENSION, subfolder="plots"
+    )
     plt.savefig(save_path)
     plt.close()
     logger.info(f"Saved: {save_path}")

--- a/analysis_view.py
+++ b/analysis_view.py
@@ -85,6 +85,15 @@ class AnalysisView:
         ttk.Entry(tag_frame, textvariable=self.app.file_tag_var, width=25).pack(
             side="left", padx=5
         )
+        ttk.Label(tag_frame, text="File type:").pack(side="left", padx=(10, 0))
+        self.file_type_combobox = ttk.Combobox(
+            tag_frame,
+            values=["pdf", "png"],
+            state="readonly",
+            textvariable=self.app.plot_ext_var,
+            width=5,
+        )
+        self.file_type_combobox.pack(side="left")
 
         button_frame = ttk.Frame(self.frame)
         button_frame.pack(pady=10)
@@ -125,6 +134,7 @@ class AnalysisView:
                 "folder": self.app.mcnp_folder_var.get(),
             },
             "file_tag": self.app.file_tag_var.get(),
+            "plot_ext": self.app.plot_ext_var.get(),
         }
         try:
             with open(CONFIG_FILE, "w") as f:
@@ -155,6 +165,7 @@ class AnalysisView:
                     self.app.mcnp_jobs_var.set(run_profile.get("jobs", 3))
                     self.app.mcnp_folder_var.set(run_profile.get("folder", ""))
                     self.app.file_tag_var.set(config.get("file_tag", ""))
+                    self.app.plot_ext_var.set(config.get("plot_ext", "pdf"))
             except Exception as e:
                 self.app.log(f"Failed to load config: {e}", logging.ERROR)
 
@@ -270,6 +281,7 @@ class AnalysisView:
         self.save_config()
         export_csv = self.app.save_csv_var.get()
         He3_Plotter.set_filename_tag(self.app.file_tag_var.get())
+        He3_Plotter.set_plot_extension(self.app.plot_ext_var.get())
         try:
             if args[0] == AnalysisType.EFFICIENCY_NEUTRON_RATES:
                 _, file_path, yield_value = args

--- a/settings_view.py
+++ b/settings_view.py
@@ -34,6 +34,15 @@ class SettingsView:
 
         ttk.Checkbutton(frame, text="Save analysis CSVs by default", variable=self.app.save_csv_var).pack(anchor="w", pady=10)
 
+        ttk.Label(frame, text="Default plot file type:").pack(anchor="w")
+        self.plot_ext_combobox = ttk.Combobox(
+            frame,
+            textvariable=self.app.plot_ext_var,
+            state="readonly",
+            values=["pdf", "png"],
+        )
+        self.plot_ext_combobox.pack(fill="x", pady=5)
+
         ttk.Label(frame, text="Select Theme:").pack(anchor="w", pady=(10, 0))
         self.theme_combobox = ttk.Combobox(frame, textvariable=self.theme_var, state="readonly")
         self.theme_combobox['values'] = ['flatly', 'darkly', 'superhero', 'cyborg', 'solar', 'vapor']
@@ -78,6 +87,7 @@ class SettingsView:
                 "save_csv": self.app.save_csv_var.get(),
                 "neutron_yield": self.app.neutron_yield.get(),
                 "theme": self.theme_var.get(),
+                "plot_ext": self.app.plot_ext_var.get(),
             }
             with open(self.app.settings_path, "w") as f:
                 json.dump(settings, f)

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -10,6 +10,8 @@ from He3_Plotter import (
     run_analysis_type_2,
     get_output_path,
     set_filename_tag,
+    set_plot_extension,
+    plot_efficiency_and_rates,
 )
 
 def test_parse_thickness_from_filename_handles_optional_cm():
@@ -156,3 +158,26 @@ def test_get_output_path_includes_tag(tmp_path):
     path = get_output_path(tmp_path, "base", "desc")
     set_filename_tag("")
     assert "experiment" in os.path.basename(path)
+
+
+def test_set_plot_extension_saves_png(tmp_path):
+    set_plot_extension("png")
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "energy": [1.0],
+            "rate_incident": [1.0],
+            "rate_detected": [0.5],
+            "rate_incident_err": [0.1],
+            "rate_detected_err": [0.05],
+            "efficiency": [0.5],
+            "efficiency_err": [0.01],
+        }
+    )
+    dummy = tmp_path / "test.o"
+    dummy.write_text("dummy")
+    plot_efficiency_and_rates(df, str(dummy))
+    png_files = list((tmp_path / "plots").glob("*.png"))
+    assert png_files, "Expected PNG plot to be saved"
+    set_plot_extension("pdf")


### PR DESCRIPTION
## Summary
- allow users to pick plot save file type via new dropdown and persistent setting
- support png and pdf output through global plot extension control
- add tests covering plot extension functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58dcdee2c83249fcce75843569d2e