### PR TITLE
Use module-specific logger in GUI

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -18,6 +18,9 @@ from analysis_view import AnalysisView
 from runner_view import RunnerView
 from settings_view import SettingsView
 
+# Module-level logger for this module
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Custom logging handler to write to GUI widgets
 # ---------------------------------------------------------------------------
@@ -45,7 +48,8 @@ class He3PlotterApp:
     """Main application coordinating the various views."""
 
     def log(self, message, level=logging.INFO):
-        self.logger.log(level, message)
+        """Log messages using the module-level logger."""
+        logger.log(level, message)
 
     def __init__(self, root):
         self.root = root
@@ -126,12 +130,8 @@ class He3PlotterApp:
             self.runner_view.runner_output_console,
         )
         gui_handler.setFormatter(logging.Formatter("%(message)s"))
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.INFO)
-        for h in list(root_logger.handlers):
-            root_logger.removeHandler(h)
-        root_logger.addHandler(gui_handler)
-        self.logger = root_logger
+        logger.setLevel(logging.INFO)
+        logger.addHandler(gui_handler)
 
     # ------------------------------------------------------------------
     def load_mcnp_path(self):


### PR DESCRIPTION
## Summary
- Scope GUI logging to module-specific logger using `logging.getLogger(__name__)`
- Attach `WidgetLoggerHandler` to the module logger so existing root handlers remain untouched
- Route `He3PlotterApp.log` through the module logger

## Testing
- `python - <<'PY'
import logging, types, sys
analysis_module = types.ModuleType('analysis_view');
class AnalysisView: pass
analysis_module.AnalysisView = AnalysisView
sys.modules['analysis_view'] = analysis_module
runner_module = types.ModuleType('runner_view');
class RunnerView: pass
runner_module.RunnerView = RunnerView
sys.modules['runner_view'] = runner_module
settings_module = types.ModuleType('settings_view');
class SettingsView: pass
settings_module.SettingsView = SettingsView
sys.modules['settings_view'] = settings_module
import GUI
from GUI import WidgetLoggerHandler, logger
class StubWidget:
    def __init__(self): self.messages=[]
    def insert(self, pos, msg): self.messages.append(msg)
    def see(self, pos): pass
main=listbox=StubWidget()
handler=WidgetLoggerHandler(main, listbox)
handler.setFormatter(logging.Formatter('%(message)s'))
logger.addHandler(handler)
logger.setLevel(logging.INFO)
logger.info('hello world')
print('main messages:', main.messages)
print('listbox messages:', listbox.messages)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59d64c7948324a50eaf3d4d433223