### PR TITLE
Check for missing MCNP executable

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -175,6 +175,9 @@ def run_mcnp(inp_file: str | Path, process_list: Optional[List[Any]] = None) -> 
     inp_path = Path(inp_file)
     file_name = inp_path.name
     file_dir = inp_path.parent
+    if not Path(MCNP_EXECUTABLE).is_file():
+        logger.error(f"MCNP executable not found at {MCNP_EXECUTABLE}")
+        return
     cmd = [str(MCNP_EXECUTABLE), "ixr", f"name={file_name}"]
     try:
         proc = subprocess.Popen(cmd, cwd=str(file_dir))

--- a/tests/test_run_packages.py
+++ b/tests/test_run_packages.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import json
+import logging
 
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -43,3 +44,12 @@ def test_gather_input_files_filters_correctly(tmp_path):
     assert set(files) == {str(inp1), str(inp2), str(keep)}
     # single mode should ignore folder
     assert run_packages.gather_input_files(tmp_path, "single") == []
+
+
+def test_run_mcnp_missing_executable_logs_error(monkeypatch, tmp_path, caplog):
+    dummy_inp = tmp_path / "case.inp"
+    dummy_inp.write_text("")
+    monkeypatch.setattr(run_packages, "MCNP_EXECUTABLE", tmp_path / "missing" / "mcnp6")
+    with caplog.at_level(logging.ERROR):
+        run_packages.run_mcnp(dummy_inp)
+    assert "MCNP executable not found" in caplog.text


### PR DESCRIPTION
## Summary
- Ensure `run_mcnp` validates `MCNP_EXECUTABLE` exists before launching a process
- Add regression test verifying missing executable logs an error without raising

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5a8f819dc832491d51c4019da9174