### PR TITLE
Refactor run_packages into library with dedicated CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+"""Command line interface for running MCNP simulations.
+
+This module provides an interactive command line interface as well as
+argument parsing so that simulations can be launched non-interactively.
+All user interaction previously embedded in :mod:`run_packages` has been
+moved here to keep :mod:`run_packages` a pure library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import logging
+import os
+from pathlib import Path
+from tkinter import Tk
+from tkinter.filedialog import askdirectory, askopenfilename
+from typing import List
+
+import run_packages
+
+
+logger = logging.getLogger(__name__)
+
+
+def _select_file_via_dialog() -> str | None:
+    """Return a file path selected via a Tk file dialog or ``None``."""
+
+    root = Tk()
+    root.withdraw()
+    selected = askopenfilename(title="Select MCNP input file to run")
+    root.destroy()
+    return selected or None
+
+
+def _select_directory_via_dialog() -> str | None:
+    """Return a directory path selected via a Tk directory dialog or ``None``."""
+
+    root = Tk()
+    root.withdraw()
+    selected = askdirectory(title="Select folder with MCNP input files")
+    root.destroy()
+    return selected or None
+
+
+def main() -> None:
+    """Entry point for the MCNP runner CLI."""
+
+    parser = argparse.ArgumentParser(description="Run MCNP simulations in parallel.")
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=3,
+        help="Number of concurrent MCNP jobs (default: 3)",
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        help="Directory containing MCNP input files",
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        choices=["all", "single"],
+        help="Run all files in a directory or a single input file",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=str,
+        help="Path to MCNP input file when running a single file",
+    )
+    parser.add_argument(
+        "-a",
+        "--action",
+        choices=["delete", "backup", "abort"],
+        help="Action if existing output files are detected",
+    )
+    args = parser.parse_args()
+
+    # Optional interactive override for the number of jobs
+    try:
+        jobs_input = input(f"Enter number of concurrent jobs [default {args.jobs}]: ")
+        if jobs_input.strip():
+            args.jobs = int(jobs_input.strip())
+    except Exception:
+        logger.warning(f"Invalid input for jobs; using default = {args.jobs}")
+
+    # Determine run mode
+    if args.mode is None:
+        run_choice = input(
+            "Enter 'a' to run all files in a folder, or 's' to run a single file: "
+        )
+        if run_choice.lower() == "s":
+            args.mode = "single"
+        elif run_choice.lower() == "a":
+            args.mode = "all"
+        else:
+            logger.warning("Invalid choice; exiting.")
+            return
+
+    input_files: List[str]
+    if args.mode == "single":
+        file_path = args.file
+        if file_path is None:
+            file_path = _select_file_via_dialog()
+            if file_path is None:
+                logger.info("No file selected; exiting.")
+                return
+        inp_path = Path(file_path)
+        if not inp_path.is_absolute():
+            inp_path = run_packages.resolve_path(inp_path)
+        mcnp_dir = inp_path.parent
+        input_files = [str(inp_path)]
+    else:  # args.mode == "all"
+        directory = args.directory
+        if directory is None:
+            directory = _select_directory_via_dialog()
+            if directory is None:
+                logger.info("No folder selected; exiting.")
+                return
+        mcnp_dir = run_packages.resolve_path(directory)
+        input_files = run_packages.gather_input_files(mcnp_dir, "multi")
+
+    if input_files:
+        ctme_value = run_packages.extract_ctme_minutes(Path(input_files[0]))
+        num_files = len(input_files)
+        estimated_parallel_time = run_packages.calculate_estimated_time(
+            ctme_value, num_files, args.jobs
+        )
+        total_ctme = ctme_value * num_files
+        logger.info(
+            f"Estimated total run time based on ctme values: {total_ctme:.1f} minutes"
+        )
+        logger.info(
+            f"Estimated actual runtime with {args.jobs} parallel jobs: {estimated_parallel_time:.1f} minutes "
+            f"({estimated_parallel_time / 60:.2f} hours)"
+        )
+        estimated_completion_time = datetime.datetime.now() + datetime.timedelta(
+            minutes=estimated_parallel_time
+        )
+        logger.info(
+            f"Estimated completion time: {estimated_completion_time.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+
+    # Check for existing outputs
+    existing_outputs = run_packages.check_existing_outputs(input_files, mcnp_dir)
+    if existing_outputs:
+        logger.info("Detected existing output files:")
+        for f in existing_outputs:
+            logger.info(f"  {f}")
+        action = args.action
+        if action is None:
+            choice = input(
+                "Enter 'd' to delete, 'm' to move to 'backup_outputs', or any other key to cancel: "
+            )
+            if choice.lower() == "d":
+                action = "delete"
+            elif choice.lower() == "m":
+                action = "backup"
+            else:
+                action = "abort"
+        if action in {"delete", "backup"}:
+            run_packages.delete_or_backup_outputs(existing_outputs, mcnp_dir, action)
+        else:
+            logger.info("Aborting run.")
+            return
+
+    if not input_files:
+        logger.warning(
+            "No input files found in directory (checked for .inp and files without extension)."
+        )
+        return
+
+    logger.info(
+        f"Found {len(input_files)} input files. Running up to {args.jobs} jobs in parallel."
+    )
+
+    run_packages.run_simulations(input_files, args.jobs)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/run_packages.py
+++ b/run_packages.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-import argparse
 import concurrent.futures
 import datetime
-import glob
 import json
 import logging
 import os
@@ -11,8 +9,6 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
-from tkinter import Tk
-from tkinter.filedialog import askdirectory, askopenfilename
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -206,108 +202,16 @@ def run_geometry_plotter(inp_file: str | Path, process_list: Optional[List[Any]]
     except Exception as e:
         logger.error(f"Error launching geometry plotter for {inp_file}: {e}")
 
+def run_simulations(input_files: Iterable[str], jobs: int) -> None:
+    """Run MCNP simulations for ``input_files`` using up to ``jobs`` workers."""
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Run MCNP simulations in parallel.")
-    parser.add_argument(
-        "-j", "--jobs",
-        type=int,
-        default=3,
-        help="Number of concurrent MCNP jobs (default: 3)",
-    )
-    parser.add_argument(
-        "-d", "--directory",
-        type=str,
-        default=None,
-        help="Directory containing MCNP input files (default: prompt via GUI)",
-    )
-    args = parser.parse_args()
-
-    # Prompt for number of concurrent jobs if desired
-    try:
-        jobs_input = input(f"Enter number of concurrent jobs [default {args.jobs}]: ")
-        if jobs_input.strip():
-            args.jobs = int(jobs_input.strip())
-    except ValueError:
-        logger.warning(f"Invalid input for jobs; using default = {args.jobs}")
-
-    # Ask whether to run all files in a folder or a single file
-    run_choice = input("Enter 'a' to run all files in a folder, or 's' to run a single file: ")
-    if run_choice.lower() == "s":
-        # Single-file run: ask for input file
-        root = Tk()
-        root.withdraw()
-        selected_file = askopenfilename(title="Select MCNP input file to run")
-        root.destroy()
-        if not selected_file:
-            logger.info("No file selected; exiting.")
-            return
-        args.directory = Path(selected_file).parent
-        mcnp_dir = resolve_path(args.directory)
-        os.chdir(str(mcnp_dir))
-        input_files = [Path(selected_file).name]
-    elif run_choice.lower() == "a":
-        # Multi-file run: ask for directory if not provided
-        if args.directory is None:
-            root = Tk()
-            root.withdraw()
-            selected = askdirectory(title="Select folder with MCNP input files")
-            root.destroy()
-            if not selected:
-                logger.info("No folder selected; exiting.")
-                return
-            args.directory = selected
-        mcnp_dir = resolve_path(args.directory)
-        os.chdir(str(mcnp_dir))
-        # Find all MCNP input files: .inp files and files without an extension
-        inp_files = list(mcnp_dir.glob("*.inp"))
-        noext_files = [f for f in mcnp_dir.glob("*") if f.is_file() and f.suffix == ""]
-        input_files = sorted({f.name for f in inp_files + noext_files})
-    else:
-        logger.warning("Invalid choice; exiting.")
-        return
-
-    if input_files:
-        ctme_value = extract_ctme_minutes(mcnp_dir / input_files[0])
-        num_files = len(input_files)
-        num_batches = (num_files + args.jobs - 1) // args.jobs
-        estimated_parallel_time = ctme_value * num_batches
-        total_ctme = ctme_value * num_files
-        logger.info(f"Estimated total run time based on ctme values: {total_ctme:.1f} minutes")
-        logger.info(
-            f"Estimated actual runtime with {args.jobs} parallel jobs: {estimated_parallel_time:.1f} minutes ({estimated_parallel_time / 60:.2f} hours)"
-        )
-        estimated_completion_time = datetime.datetime.now() + datetime.timedelta(minutes=estimated_parallel_time)
-        logger.info(f"Estimated completion time: {estimated_completion_time.strftime('%Y-%m-%d %H:%M:%S')}")
-
-    # Check for existing MCNP output files and prompt user
-    existing_outputs = check_existing_outputs(input_files, mcnp_dir)
-    if existing_outputs:
-        logger.info("Detected existing output files:")
-        for f in existing_outputs:
-            logger.info(f"  {f}")
-        choice = input("Enter 'd' to delete, 'm' to move to 'backup_outputs', or any other key to cancel: ")
-        if choice.lower() == "d":
-            delete_or_backup_outputs(existing_outputs, mcnp_dir, "delete")
-        elif choice.lower() == "m":
-            delete_or_backup_outputs(existing_outputs, mcnp_dir, "backup")
-        else:
-            logger.info("Aborting run.")
-            return
-
-    if not input_files:
-        logger.warning("No input files found in directory (checked for .inp and files without extension).")
-        return
-
-    logger.info(f"Found {len(input_files)} input files. Running up to {args.jobs} jobs in parallel.")
-
-    # Run with a process pool to limit concurrency
-    with concurrent.futures.ProcessPoolExecutor(max_workers=args.jobs) as executor:
-        # Schedule and run all simulations, collecting results to force execution
+    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as executor:
         for _ in executor.map(run_mcnp, input_files):
             pass
 
 
 if __name__ == "__main__":
-    main()
+    from cli import main as cli_main
+
+    cli_main()
 


### PR DESCRIPTION
## Summary
- add new `cli` module to handle argument parsing and interactive prompts
- convert `run_packages` into a pure library with `run_simulations` helper
- redirect `run_packages` script entry to the CLI module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b0b3e3a0832498df6dabf8933df7