### PR TITLE
Fix logging configuration so saved plot paths display

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -130,8 +130,19 @@ class He3PlotterApp:
             self.runner_view.runner_output_console,
         )
         gui_handler.setFormatter(logging.Formatter("%(message)s"))
-        logger.setLevel(logging.INFO)
-        logger.addHandler(gui_handler)
+
+        # Attach the handler to the root logger so that logs from all modules
+        # propagate to the GUI. Previously the handler was only attached to the
+        # ``GUI`` module's logger which meant messages emitted from other
+        # modules (e.g. ``he3_plotter.analysis``) were not intercepted. As a
+        # result, paths to saved plots logged via ``logger.info("Saved: ...")``
+        # never reached the ``WidgetLoggerHandler`` and the "Saved Plots" list
+        # remained empty. By registering the handler with the root logger we
+        # ensure that all log records, regardless of their originating module,
+        # are captured and displayed in the application.
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.INFO)
+        root_logger.addHandler(gui_handler)
 
     # ------------------------------------------------------------------
     def load_mcnp_path(self):

--- a/tests/test_logging_saved_plots.py
+++ b/tests/test_logging_saved_plots.py
@@ -1,0 +1,29 @@
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from GUI import WidgetLoggerHandler
+
+class DummyListbox:
+    def __init__(self):
+        self.items = []
+    def insert(self, index, value):
+        self.items.append(value)
+
+
+def test_widget_logger_captures_saved_plot_path(tmp_path):
+    listbox = DummyListbox()
+    handler = WidgetLoggerHandler(None, listbox, None)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger = logging.getLogger()
+    old_handlers = root_logger.handlers[:]
+    root_logger.handlers = [handler]
+    root_logger.setLevel(logging.INFO)
+    try:
+        logging.getLogger("he3_plotter.analysis").info(
+            f"Saved: {tmp_path/'plot.pdf'}"
+        )
+    finally:
+        root_logger.handlers = old_handlers
+    assert listbox.items == [str(tmp_path/'plot.pdf')]


### PR DESCRIPTION
## Summary
- Ensure GUI logging handler is attached to the root logger so messages from all modules (like saved plot notifications) populate the Saved Plots list.
- Add regression test verifying that "Saved:" log messages update the listbox via `WidgetLoggerHandler`.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b467e7c083248483970e8c7cf27a