### PR TITLE
Ignore hidden files and handle binary ctme

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -98,6 +98,7 @@ def gather_input_files(folder: str | Path, mode: str) -> List[str]:
         for f in folder.glob("*")
         if f.is_file()
         and f.suffix == ""
+        and not f.name.startswith(".")
         and not any(f.name.endswith(suffix) for suffix in known_output_suffixes)
     ]
     return [str(f) for f in inp_files]
@@ -146,7 +147,7 @@ def extract_ctme_minutes(file_path: str | Path) -> float:
     """Return the last ``ctme`` value (minutes) found in ``file_path``."""
 
     try:
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
             lines = f.readlines()
             for line in reversed(lines):
                 match = re.search(r"\bctme\s+(\d+(\.\d+)?)", line, re.IGNORECASE)

--- a/tests/test_run_packages.py
+++ b/tests/test_run_packages.py
@@ -39,6 +39,7 @@ def test_gather_input_files_filters_correctly(tmp_path):
     (tmp_path / "resultr").write_text("")  # extensionless ending with r
     (tmp_path / "ignored.txt").write_text("")  # has extension
     (tmp_path / "ignored.o").write_text("")  # known output extension
+    (tmp_path / ".DS_Store").write_text("")  # hidden file
 
     files = run_packages.gather_input_files(tmp_path, "multi")
     assert set(files) == {str(inp1), str(inp2), str(keep)}
@@ -53,3 +54,12 @@ def test_run_mcnp_missing_executable_logs_error(monkeypatch, tmp_path, caplog):
     with caplog.at_level(logging.ERROR):
         run_packages.run_mcnp(dummy_inp)
     assert "MCNP executable not found" in caplog.text
+
+
+def test_extract_ctme_minutes_handles_binary_file(tmp_path, caplog):
+    binary = tmp_path / "binaryfile"
+    binary.write_bytes(b"\xb8\x00\x00")
+    with caplog.at_level(logging.ERROR):
+        value = run_packages.extract_ctme_minutes(binary)
+    assert value == 0.0
+    assert "Error reading ctme" not in caplog.text


### PR DESCRIPTION
## Summary
- Skip hidden files like `.DS_Store` when gathering MCNP input files
- Ignore decoding errors when reading `ctme` values
- Test `extract_ctme_minutes` against binary files and hidden files in `gather_input_files`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6942d1c8324b6cf5d227b9cfaf4