### PR TITLE
Handle multi-surface MCNP tallies in plots

### DIFF
--- a/he3_plotter/plots.py
+++ b/he3_plotter/plots.py
@@ -12,28 +12,60 @@ logger = logging.getLogger(__name__)
 
 
 def plot_efficiency_and_rates(df, filename):
+    """Plot incident/detected rates and efficiencies.
+
+    If a ``surface`` column is present, each surface is plotted separately so
+    multiple tally pairs can be visualised on the same axes.
+    """
+
     base_name = os.path.splitext(os.path.basename(filename))[0]
     base_dir = os.path.dirname(filename)
 
     plt.figure(figsize=(10, 6))
-    plt.errorbar(
-        df["energy"],
-        df["rate_incident"],
-        yerr=df["rate_incident_err"],
-        label="Incident Rate",
-        fmt="o-",
-        markersize=3,
-        capsize=2,
-    )
-    plt.errorbar(
-        df["energy"],
-        df["rate_detected"],
-        yerr=df["rate_detected_err"],
-        label="Detected Rate",
-        fmt="s-",
-        markersize=3,
-        capsize=2,
-    )
+
+    if "surface" in df.columns:
+        for i, (surface, grp) in enumerate(df.groupby("surface")):
+            color = f"C{i}"
+            plt.errorbar(
+                grp["energy"],
+                grp["rate_incident"],
+                yerr=grp["rate_incident_err"],
+                label=f"Incident Rate (Surface {surface})",
+                fmt="o-",
+                color=color,
+                markersize=3,
+                capsize=2,
+            )
+            plt.errorbar(
+                grp["energy"],
+                grp["rate_detected"],
+                yerr=grp["rate_detected_err"],
+                label=f"Detected Rate (Surface {surface})",
+                fmt="s-",
+                color=color,
+                markersize=3,
+                capsize=2,
+            )
+    else:
+        plt.errorbar(
+            df["energy"],
+            df["rate_incident"],
+            yerr=df["rate_incident_err"],
+            label="Incident Rate",
+            fmt="o-",
+            markersize=3,
+            capsize=2,
+        )
+        plt.errorbar(
+            df["energy"],
+            df["rate_detected"],
+            yerr=df["rate_detected_err"],
+            label="Detected Rate",
+            fmt="s-",
+            markersize=3,
+            capsize=2,
+        )
+
     plt.xlabel("Energy (MeV)")
     plt.ylabel("Neutron Rate")
     plt.title("Neutron Rates vs Energy")
@@ -47,15 +79,31 @@ def plot_efficiency_and_rates(df, filename):
     logger.info(f"Saved: {rate_path}")
 
     plt.figure(figsize=(8, 6))
-    plt.errorbar(
-        df["energy"],
-        df["efficiency"],
-        yerr=df["efficiency_err"],
-        fmt="^-",
-        color="green",
-        markersize=3,
-        capsize=2,
-    )
+
+    if "surface" in df.columns:
+        for i, (surface, grp) in enumerate(df.groupby("surface")):
+            color = f"C{i}"
+            plt.errorbar(
+                grp["energy"],
+                grp["efficiency"],
+                yerr=grp["efficiency_err"],
+                fmt="^-",
+                color=color,
+                markersize=3,
+                capsize=2,
+                label=f"Surface {surface}",
+            )
+    else:
+        plt.errorbar(
+            df["energy"],
+            df["efficiency"],
+            yerr=df["efficiency_err"],
+            fmt="^-",
+            color="green",
+            markersize=3,
+            capsize=2,
+        )
+
     plt.xlabel("Energy (MeV)")
     plt.ylabel("Detection Efficiency")
     plt.title("Efficiency vs Energy")

--- a/tests/test_logging_saved_plots.py
+++ b/tests/test_logging_saved_plots.py
@@ -81,3 +81,27 @@ def test_plot_efficiency_and_rates_logs_paths(tmp_path, caplog):
     assert len(saved_paths) == 2
     for p in saved_paths:
         assert Path(p).exists()
+
+
+def test_plot_efficiency_and_rates_multiple_surfaces(tmp_path, caplog):
+    df = pd.DataFrame(
+        {
+            "energy": [1.0, 1.0],
+            "rate_incident": [1.0, 2.0],
+            "rate_detected": [0.5, 1.0],
+            "rate_incident_err": [0.1, 0.2],
+            "rate_detected_err": [0.05, 0.1],
+            "efficiency": [0.5, 0.5],
+            "efficiency_err": [0.01, 0.02],
+            "surface": [1, 2],
+        }
+    )
+    dummy = tmp_path / "test_multi.o"
+    dummy.write_text("dummy")
+    with caplog.at_level(logging.INFO, logger="he3_plotter.plots"):
+        plot_efficiency_and_rates(df, dummy)
+    messages = [rec.message for rec in caplog.records if "Saved:" in rec.message]
+    saved_paths = [m.split("Saved:", 1)[1].strip() for m in messages]
+    assert len(saved_paths) == 2
+    for p in saved_paths:
+        assert Path(p).exists()


### PR DESCRIPTION
## Summary
- Plot incident/detected rates separately for each surface when multiple tallies are present
- Support multi-surface efficiency plotting
- Test plotting with multiple surface tallies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72db588708324a2161052fd295ecc