### PR TITLE
Add selectable Li6I(Eu) detector geometry to analysis

### DIFF
--- a/he3_plotter/__init__.py
+++ b/he3_plotter/__init__.py
@@ -1,8 +1,9 @@
-from . import analysis, io_utils, plots, config
+from . import analysis, io_utils, plots, config, detectors
 
 __all__ = [
     'analysis',
     'io_utils',
     'plots',
     'config',
+    'detectors',
 ]

--- a/he3_plotter/analysis.py
+++ b/he3_plotter/analysis.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 
 from .io_utils import get_output_path
 from .plots import plot_efficiency_and_rates
+from .detectors import DETECTORS, DEFAULT_DETECTOR
 
 logger = logging.getLogger(__name__)
 
@@ -178,11 +179,12 @@ def parse_thickness_from_filename(filename):
 
 
 # Geometry constants
-LENGTH_CM = 100.0
-DIAMETER_CM = 5.0
-RADIUS_CM = DIAMETER_CM / 2.0
-AREA = LENGTH_CM * DIAMETER_CM
-VOLUME = np.pi * (RADIUS_CM ** 2) * LENGTH_CM
+_DEFAULT_GEOM = DETECTORS[DEFAULT_DETECTOR]
+LENGTH_CM = _DEFAULT_GEOM.length_cm
+RADIUS_CM = _DEFAULT_GEOM.radius_cm
+DIAMETER_CM = RADIUS_CM * 2.0
+AREA = _DEFAULT_GEOM.area
+VOLUME = _DEFAULT_GEOM.volume
 
 EXP_RATE = 247.0333333
 EXP_ERR = 0.907438397

--- a/he3_plotter/detectors.py
+++ b/he3_plotter/detectors.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class DetectorGeometry:
+    """Cylindrical detector geometry in centimetres."""
+
+    length_cm: float
+    radius_cm: float
+
+    @property
+    def area(self) -> float:
+        """Surface area of the side (length × diameter)."""
+        return self.length_cm * (self.radius_cm * 2)
+
+    @property
+    def volume(self) -> float:
+        """Volume of the cylinder."""
+        return math.pi * (self.radius_cm ** 2) * self.length_cm
+
+
+DETECTORS = {
+    "He3": DetectorGeometry(length_cm=100.0, radius_cm=2.5),
+    "Li6I(Eu)": DetectorGeometry(length_cm=2.5, radius_cm=0.3),
+}
+
+DEFAULT_DETECTOR = "He3"

--- a/tests/test_analysis_config.py
+++ b/tests/test_analysis_config.py
@@ -59,6 +59,8 @@ def create_analysis_view(app, AnalysisType, analysis_view_module):
         AnalysisType.PHOTON_TALLY_PLOT: "Photon Tally Plot",
     }
     av.analysis_combobox = DummyCombobox()
+    av.detector_var = DummyVar("He3")
+    av.detector_combobox = DummyCombobox()
     return av
 
 

--- a/tests/test_analysis_threadpool.py
+++ b/tests/test_analysis_threadpool.py
@@ -95,6 +95,7 @@ def setup_view(monkeypatch, *, raise_error=False):
     }
     av._executor = ThreadPoolExecutor(max_workers=1)
     av.save_config = lambda: None
+    av.detector_var = DummyVar("He3")
     return av, app, module
 
 

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -14,6 +14,14 @@ from he3_plotter.analysis import (
 from he3_plotter.io_utils import get_output_path
 from he3_plotter.config import set_filename_tag, set_plot_extension
 from he3_plotter.plots import plot_efficiency_and_rates
+from he3_plotter.detectors import DETECTORS
+
+def test_li6i_detector_geometry():
+    geom = DETECTORS["Li6I(Eu)"]
+    assert geom.length_cm == 2.5
+    assert geom.radius_cm == 0.3
+    assert geom.area == 2.5 * 0.6
+    assert abs(geom.volume - (3.141592653589793 * 0.09 * 2.5)) < 1e-6
 
 def test_parse_thickness_from_filename_handles_optional_cm():
     assert parse_thickness_from_filename("example_10cmo") == 10


### PR DESCRIPTION
## Summary
- Add detectors module defining geometry for He3 and new Li6I(Eu) cylinders.
- Add detector selection drop-down in analysis view and persist choice to config.
- Use selected detector dimensions when running analyses and update tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a873dafdf4832486b4fdf01f3fb9b1