### PR TITLE
Centralize logging configuration with override options

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from analysis_view import AnalysisView
 from runner_view import RunnerView
 from settings_view import SettingsView
+import logging_config
 
 # Module-level logger for this module
 logger = logging.getLogger(__name__)
@@ -163,7 +164,6 @@ class He3PlotterApp:
         # ensure that all log records, regardless of their originating module,
         # are captured and displayed in the application.
         root_logger = logging.getLogger()
-        root_logger.setLevel(logging.INFO)
         root_logger.addHandler(gui_handler)
 
     # ------------------------------------------------------------------
@@ -213,6 +213,7 @@ class He3PlotterApp:
 
 
 if __name__ == "__main__":
+    logging_config.configure()
     if tkdnd:
         root = tkdnd.TkinterDnD.Tk()
     else:

--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,7 @@ from tkinter.filedialog import askdirectory, askopenfilename
 from typing import List
 
 import run_packages
+import logging_config
 
 
 logger = logging.getLogger(__name__)
@@ -89,7 +90,16 @@ def main() -> None:
         action="store_true",
         help="Prompt for missing values interactively",
     )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help=(
+            "Set the logging level. Can also be configured via the "
+            "LOG_LEVEL environment variable"
+        ),
+    )
     args = parser.parse_args()
+    logging_config.configure(args.log_level)
 
     # Optional interactive override for the number of jobs
     if args.interactive:

--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -36,6 +36,13 @@ Command Line Usage
 • Choose how to handle existing outputs with `-a delete`, `backup`, or `abort`.
 
 ========================
+Logging
+========================
+• Log messages default to `INFO` level.
+• Override via the `LOG_LEVEL` environment variable (e.g. `LOG_LEVEL=DEBUG`).
+• For the CLI, use `--log-level` to set the level explicitly.
+
+========================
 Analysing Results
 ========================
 1. Select Neutron Sources

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,31 @@
+"""Centralised logging configuration for MCNP Tools.
+
+This module applies :func:`logging.basicConfig` with a default format and
+level. The log level can be overridden via the ``LOG_LEVEL`` environment
+variable or by passing an explicit level to :func:`configure`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Union
+
+DEFAULT_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+
+def configure(level: Union[str, int, None] = None) -> None:
+    """Configure the root logger.
+
+    Parameters
+    ----------
+    level:
+        Logging level to apply. If ``None``, the ``LOG_LEVEL`` environment
+        variable is consulted and defaults to ``INFO`` if unset.
+    """
+
+    if level is None:
+        level = os.getenv("LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(level=level, format=DEFAULT_FORMAT, force=True)


### PR DESCRIPTION
## Summary
- add `logging_config` module to centralize logging setup using `LOG_LEVEL`
- wire up CLI and GUI to use logging configuration with optional `--log-level` flag
- document log level overrides via environment variable or CLI flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88674e9e083249700e518ce3043f4