### PR TITLE
Add mesh tally runner with filename validation

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -190,6 +190,33 @@ def run_geometry_plotter(inp_file: str | Path, process_list: Optional[List[Any]]
     except Exception as e:
         logger.error(f"Error launching geometry plotter for {inp_file}: {e}")
 
+
+def run_mesh_tally(runtpe_file: str | Path, process_list: Optional[List[Any]] = None) -> None:
+    """Run the MCNP mesh tally post-processing for ``runtpe_file``."""
+
+    runtpe_path = Path(runtpe_file)
+    if not runtpe_path.name.endswith("r"):
+        logger.error(f"Mesh tally runtpe file must end with 'r': {runtpe_file}")
+        return
+    if not runtpe_path.is_file():
+        logger.error(f"Runtpe file not found: {runtpe_file}")
+        return
+    if not Path(MCNP_EXECUTABLE).is_file():
+        logger.error(f"MCNP executable not found at {MCNP_EXECUTABLE}")
+        return
+    file_dir = runtpe_path.parent
+    cmd = [str(MCNP_EXECUTABLE), "z", f"runtpe={runtpe_path.name}"]
+    try:
+        proc = subprocess.Popen(cmd, cwd=str(file_dir))
+        if process_list is not None:
+            process_list.append(proc)
+        return_code = proc.wait()
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, cmd)
+        logger.info(f"Mesh tally completed: {runtpe_file}")
+    except Exception as e:
+        logger.error(f"Error running mesh tally for {runtpe_file}: {e}")
+
 def run_simulations(input_files: Iterable[str], jobs: int) -> None:
     """Run MCNP simulations for ``input_files`` using up to ``jobs`` workers."""
 

--- a/tests/test_run_packages.py
+++ b/tests/test_run_packages.py
@@ -63,3 +63,20 @@ def test_extract_ctme_minutes_handles_binary_file(tmp_path, caplog):
         value = run_packages.extract_ctme_minutes(binary)
     assert value == 0.0
     assert "Error reading ctme" not in caplog.text
+
+
+def test_run_mesh_tally_invalid_suffix_logs_error(tmp_path, caplog):
+    runtpe = tmp_path / "pi_2cm"
+    runtpe.write_text("")
+    with caplog.at_level(logging.ERROR):
+        run_packages.run_mesh_tally(runtpe)
+    assert "must end with 'r'" in caplog.text
+
+
+def test_run_mesh_tally_missing_executable_logs_error(monkeypatch, tmp_path, caplog):
+    runtpe = tmp_path / "pi_2cmr"
+    runtpe.write_text("")
+    monkeypatch.setattr(run_packages, "MCNP_EXECUTABLE", tmp_path / "missing" / "mcnp6")
+    with caplog.at_level(logging.ERROR):
+        run_packages.run_mesh_tally(runtpe)
+    assert "MCNP executable not found" in caplog.text


### PR DESCRIPTION
## Summary
- add `run_mesh_tally` helper to execute mesh tally post-processing
- ensure provided runtpe filename ends with `r`
- cover new functionality with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aee83da6f883249653aa090f5af553