### PR TITLE
feat: add optional tagged plot titles

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -119,6 +119,7 @@ class He3PlotterApp:
                 self.theme_var = tk.StringVar(value=settings.get("theme", "flatly"))
                 self.file_tag_var = tk.StringVar(value=settings.get("file_tag", ""))
                 self.plot_ext_var = tk.StringVar(value=settings.get("plot_ext", "pdf"))
+                self.show_fig_heading_var = tk.BooleanVar(value=settings.get("show_fig_heading", True))
             except Exception:
                 self.default_jobs_var = tk.IntVar(value=3)
                 self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -128,6 +129,7 @@ class He3PlotterApp:
                 self.theme_var = tk.StringVar(value="flatly")
                 self.file_tag_var = tk.StringVar(value="")
                 self.plot_ext_var = tk.StringVar(value="pdf")
+                self.show_fig_heading_var = tk.BooleanVar(value=True)
         else:
             self.default_jobs_var = tk.IntVar(value=3)
             self.mcnp_jobs_var = tk.IntVar(value=3)
@@ -137,6 +139,7 @@ class He3PlotterApp:
             self.theme_var = tk.StringVar(value="flatly")
             self.file_tag_var = tk.StringVar(value="")
             self.plot_ext_var = tk.StringVar(value="pdf")
+            self.show_fig_heading_var = tk.BooleanVar(value=True)
 
         # Shared variables for runner view
         self.mcnp_folder_var = tk.StringVar()

--- a/analysis_view.py
+++ b/analysis_view.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Optional, Tuple
 import ttkbootstrap as ttk
 
 from he3_plotter.io_utils import select_file, select_folder
-from he3_plotter.config import set_filename_tag, set_plot_extension
+from he3_plotter.config import set_filename_tag, set_plot_extension, set_show_fig_heading
 from he3_plotter.analysis import (
     run_analysis_type_1,
     run_analysis_type_2,
@@ -194,6 +194,7 @@ class AnalysisView:
             "file_tag": self.app.file_tag_var.get(),
             "plot_ext": self.app.plot_ext_var.get(),
             "detector": self.detector_var.get(),
+            "show_fig_heading": self.app.show_fig_heading_var.get(),
         }
         try:
             with open(CONFIG_FILE, "w") as f:
@@ -232,6 +233,7 @@ class AnalysisView:
                     self.app.plot_ext_var.set(config.get("plot_ext", "pdf"))
                     self.detector_var.set(config.get("detector", DEFAULT_DETECTOR))
                     self.detector_combobox.set(self.detector_var.get())
+                    self.app.show_fig_heading_var.set(config.get("show_fig_heading", True))
             except Exception as e:
                 self.app.log(f"Failed to load config: {e}", logging.ERROR)
 
@@ -422,6 +424,7 @@ class AnalysisView:
         export_csv = self.app.save_csv_var.get()
         set_filename_tag(self.app.file_tag_var.get())
         set_plot_extension(self.app.plot_ext_var.get())
+        set_show_fig_heading(self.app.show_fig_heading_var.get())
         analysis_type = args[0]
         if analysis_type == AnalysisType.EFFICIENCY_NEUTRON_RATES:
             _, file_path, yield_value, area, volume = args

--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -85,6 +85,7 @@ Settings
 • Change the `MY_MCNP` path or set the default number of parallel jobs.
 • Choose whether to save analysis CSVs by default.
 • Select a theme (flatly, darkly, superhero, cyborg, solar, vapor).
+• Toggle plot titles on saved figures.
 • Use **Save Settings** to persist preferences or **Reset Settings** to clear them.
 
 ========================

--- a/he3_plotter/analysis.py
+++ b/he3_plotter/analysis.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from .io_utils import get_output_path, select_file
 from .plots import plot_efficiency_and_rates
 from .detectors import DETECTORS, DEFAULT_DETECTOR
+from .config import config
 
 logger = logging.getLogger(__name__)
 
@@ -391,9 +392,13 @@ def run_analysis_type_2(
             linestyle="--",
             color="black",
         )
-        plt.title("Simulated vs Experimental Neutron Detection")
+        if config.show_fig_heading:
+            tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+            plt.title(f"Simulated vs Experimental Neutron Detection{tag}")
     else:
-        plt.title("Simulated Neutron Detection")
+        if config.show_fig_heading:
+            tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+            plt.title(f"Simulated Neutron Detection{tag}")
     plt.xlabel("Moderator Thickness (cm)")
     plt.ylabel("Counts Per Second (CPS)")
     plt.grid(True)
@@ -514,7 +519,9 @@ def run_analysis_type_3(
     )
     plt.xlabel("Source Displacement (cm)")
     plt.ylabel("Total Detected Rate")
-    plt.title("Detected Rate vs Source Displacement")
+    if config.show_fig_heading:
+        tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+        plt.title(f"Detected Rate vs Source Displacement{tag}")
     plt.grid(True)
     plt.legend()
     plt.tight_layout()
@@ -555,7 +562,9 @@ def run_analysis_type_4(file_path, export_csv=True):
     plt.plot(df_photon["photon_energy"], df_photon["photons"], label="Photons")
     plt.xlabel("Photon Energy (MeV)")
     plt.ylabel("Photon Counts")
-    plt.title("Photon Tally (Tally 34)")
+    if config.show_fig_heading:
+        tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+        plt.title(f"Photon Tally (Tally 34){tag}")
     plt.grid(True)
     plt.legend()
     plt.tight_layout()

--- a/he3_plotter/config.py
+++ b/he3_plotter/config.py
@@ -7,6 +7,7 @@ class PlotterConfig:
 
     filename_tag: str = ""
     plot_extension: str = "pdf"
+    show_fig_heading: bool = True
 
 
 config = PlotterConfig()
@@ -23,3 +24,9 @@ def set_plot_extension(extension: str) -> None:
 
     ext = extension.strip().lower()
     config.plot_extension = ext if ext else "pdf"
+
+
+def set_show_fig_heading(show: bool) -> None:
+    """Enable or disable plot titles."""
+
+    config.show_fig_heading = bool(show)

--- a/he3_plotter/plots.py
+++ b/he3_plotter/plots.py
@@ -6,6 +6,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from .io_utils import get_output_path
+from .config import config
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,9 @@ def plot_efficiency_and_rates(df, filename):
 
     plt.xlabel("Energy (MeV)")
     plt.ylabel("Neutron Rate")
-    plt.title("Neutron Rates vs Energy")
+    if config.show_fig_heading:
+        tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+        plt.title(f"Neutron Rates vs Energy{tag}")
     plt.legend()
     plt.grid(True)
     plt.semilogx()
@@ -106,7 +109,9 @@ def plot_efficiency_and_rates(df, filename):
 
     plt.xlabel("Energy (MeV)")
     plt.ylabel("Detection Efficiency")
-    plt.title("Efficiency vs Energy")
+    if config.show_fig_heading:
+        tag = f" - {config.filename_tag.strip()}" if config.filename_tag.strip() else ""
+        plt.title(f"Efficiency vs Energy{tag}")
     plt.grid(True)
     plt.semilogx()
     plt.tight_layout()

--- a/settings_view.py
+++ b/settings_view.py
@@ -39,6 +39,12 @@ class SettingsView:
 
         ttk.Checkbutton(frame, text="Save analysis CSVs by default", variable=self.app.save_csv_var).pack(anchor="w", pady=10)
 
+        ttk.Checkbutton(
+            frame,
+            text="Show plot titles",
+            variable=self.app.show_fig_heading_var,
+        ).pack(anchor="w")
+
         ttk.Label(frame, text="Default plot file type:").pack(anchor="w")
         self.plot_ext_combobox = ttk.Combobox(
             frame,
@@ -99,6 +105,7 @@ class SettingsView:
                 "neutron_yield": self.app.neutron_yield.get(),
                 "theme": self.theme_var.get(),
                 "plot_ext": self.app.plot_ext_var.get(),
+                "show_fig_heading": self.app.show_fig_heading_var.get(),
             }
             with open(self.app.settings_path, "w") as f:
                 json.dump(settings, f)

--- a/tests/test_analysis_config.py
+++ b/tests/test_analysis_config.py
@@ -36,6 +36,7 @@ class DummyApp:
         self.mcnp_folder_var = DummyVar("")
         self.file_tag_var = DummyVar("")
         self.plot_ext_var = DummyVar("pdf")
+        self.show_fig_heading_var = DummyVar(True)
 
     def log(self, *args, **kwargs):
         pass
@@ -73,6 +74,7 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     config = types.ModuleType("he3_plotter.config")
     config.set_filename_tag = lambda *args, **kwargs: None
     config.set_plot_extension = lambda *args, **kwargs: None
+    config.set_show_fig_heading = lambda *args, **kwargs: None
     analysis = types.ModuleType("he3_plotter.analysis")
     analysis.run_analysis_type_1 = lambda *args, **kwargs: None
     analysis.run_analysis_type_2 = lambda *args, **kwargs: None
@@ -102,6 +104,7 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     app.mcnp_folder_var.set("/data")
     app.file_tag_var.set("tag")
     app.plot_ext_var.set("png")
+    app.show_fig_heading_var.set(False)
 
     av.save_config()
 
@@ -112,6 +115,7 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     assert data["sources"]["Small tank (1.25e6)"] is True
     assert data["custom_source"] == {"enabled": True, "value": "9e5"}
     assert data["run_profile"] == {"jobs": 5, "folder": "/data"}
+    assert data["show_fig_heading"] is False
 
     # Load config into a fresh instance with different starting values
     app2 = DummyApp()
@@ -132,3 +136,4 @@ def test_save_and_load_config(tmp_path, monkeypatch):
     assert app2.mcnp_folder_var.get() == "/data"
     assert app2.file_tag_var.get() == "tag"
     assert app2.plot_ext_var.get() == "png"
+    assert app2.show_fig_heading_var.get() is False

--- a/tests/test_analysis_threadpool.py
+++ b/tests/test_analysis_threadpool.py
@@ -34,6 +34,7 @@ class DummyApp:
         self.save_csv_var = DummyVar(False)
         self.file_tag_var = DummyVar("")
         self.plot_ext_var = DummyVar("pdf")
+        self.show_fig_heading_var = DummyVar(True)
         self.logged = []
 
     def log(self, message, level=logging.INFO):
@@ -49,6 +50,7 @@ def setup_view(monkeypatch, *, raise_error=False):
     config = types.ModuleType("he3_plotter.config")
     config.set_filename_tag = lambda *args, **kwargs: None
     config.set_plot_extension = lambda *args, **kwargs: None
+    config.set_show_fig_heading = lambda *args, **kwargs: None
     analysis = types.ModuleType("he3_plotter.analysis")
 
     def run1(*args, **kwargs):

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -186,6 +186,46 @@ def test_get_output_path_includes_tag(tmp_path):
     assert "experiment" in path.name
 
 
+def test_plot_titles_respect_tag_and_toggle(tmp_path, monkeypatch):
+    set_filename_tag("tag1")
+    from he3_plotter.config import set_show_fig_heading
+    set_show_fig_heading(True)
+
+    import pandas as pd
+    from he3_plotter import plots
+
+    df = pd.DataFrame(
+        {
+            "energy": [1.0],
+            "rate_incident": [1.0],
+            "rate_detected": [0.5],
+            "rate_incident_err": [0.1],
+            "rate_detected_err": [0.05],
+            "efficiency": [0.5],
+            "efficiency_err": [0.01],
+        }
+    )
+    dummy = tmp_path / "test.o"
+    dummy.write_text("dummy")
+
+    titles = []
+
+    def capture_title(text):
+        titles.append(text)
+
+    monkeypatch.setattr(plots.plt, "title", capture_title)
+    plots.plot_efficiency_and_rates(df, dummy)
+    assert titles and all("tag1" in t for t in titles)
+
+    titles.clear()
+    set_show_fig_heading(False)
+    plots.plot_efficiency_and_rates(df, dummy)
+    assert titles == []
+
+    set_filename_tag("")
+    set_show_fig_heading(True)
+
+
 def test_set_plot_extension_saves_png(tmp_path):
     set_plot_extension("png")
     import pandas as pd


### PR DESCRIPTION
## Summary
- allow users to toggle plot titles from the Settings tab
- include the filename tag in figure titles when headings are shown
- document new option and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01fa8cb74832483c459fd2c9ce81f