### PR TITLE
Add origin-based mesh planning helper

### DIFF
--- a/tests/test_mesh_bins_helper.py
+++ b/tests/test_mesh_bins_helper.py
@@ -1,0 +1,14 @@
+from mesh_bins_helper import plan_mesh_from_origin
+
+def test_plan_mesh_from_origin_uniform():
+    origin = (0.0, 0.0, 0.0)
+    result = plan_mesh_from_origin(origin, 6.0, 4.0, 3.0, delta=0.25)
+    data = result["result"]
+    assert data["iints"] == 24
+    assert data["jints"] == 16
+    assert data["kints"] == 12
+    # ensure edges are computed
+    edges = result["edges"]
+    assert len(edges["x"]) == 25
+    assert edges["x"][0] == origin[0]
+    assert edges["x"][-1] == 6.0


### PR DESCRIPTION
## Summary
- allow specifying meshes via origin and IMESH/JMESH/KMESH
- provide FMESH-style `iints`, `jints`, and `kints` aliases
- cover origin-based planning with new unit test

## Testing
- `pytest -q`
- `python mesh_bins_helper.py --origin 0 0 0 --imesh 6 --jmesh 4 --kmesh 3 --delta 0.25`

------
https://chatgpt.com/codex/tasks/task_e_68c160ef30348324950566fd746160b0