### PR TITLE
Add mesh tally analysis tab with bin helper

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover - optional dependency
 from analysis_view import AnalysisView
 from runner_view import RunnerView
 from settings_view import SettingsView
+from mesh_view import MeshTallyView
 import logging_config
 
 # Module-level logger for this module
@@ -189,16 +190,19 @@ class He3PlotterApp:
 
         self.runner_tab = ttk.Frame(self.tabs)
         self.analysis_tab = ttk.Frame(self.tabs)
+        self.mesh_tab = ttk.Frame(self.tabs)
         self.help_tab = ttk.Frame(self.tabs)
         self.settings_tab = ttk.Frame(self.tabs)
 
         self.tabs.add(self.runner_tab, text="Run MCNP")
         self.tabs.add(self.analysis_tab, text="Analysis")
+        self.tabs.add(self.mesh_tab, text="Mesh Tally")
         self.tabs.add(self.help_tab, text="How to Use")
         self.tabs.add(self.settings_tab, text="Settings")
 
         self.runner_view = RunnerView(self, self.runner_tab)
         self.analysis_view = AnalysisView(self, self.analysis_tab)
+        self.mesh_view = MeshTallyView(self, self.mesh_tab)
         self.settings_view = SettingsView(self, self.settings_tab)
 
         help_label = tk.Label(self.help_tab, text="How to Use MCNP Tools", font=("Arial", 14, "bold"))

--- a/mesh_view.py
+++ b/mesh_view.py
@@ -1,0 +1,98 @@
+import json
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+from typing import Any
+
+import ttkbootstrap as ttk
+from ttkbootstrap.dialogs import Messagebox
+
+from mesh_bins_helper import plan_mesh
+
+
+class MeshTallyView:
+    """UI for mesh tally related tools."""
+
+    def __init__(self, app: Any, parent: tk.Widget) -> None:
+        self.app = app
+        self.frame = parent
+
+        # Variables for bin helper inputs
+        self.xmin_var = tk.StringVar()
+        self.xmax_var = tk.StringVar()
+        self.ymin_var = tk.StringVar()
+        self.ymax_var = tk.StringVar()
+        self.zmin_var = tk.StringVar()
+        self.zmax_var = tk.StringVar()
+        self.delta_var = tk.StringVar()
+        self.mode_var = tk.StringVar(value="uniform")
+
+        self.build()
+
+    # ------------------------------------------------------------------
+    def build(self) -> None:
+        """Construct the mesh tally tab widgets."""
+
+        helper_frame = ttk.LabelFrame(self.frame, text="Bin Helper")
+        helper_frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        # Grid for extent entries
+        labels = [
+            ("xmin", self.xmin_var),
+            ("xmax", self.xmax_var),
+            ("ymin", self.ymin_var),
+            ("ymax", self.ymax_var),
+            ("zmin", self.zmin_var),
+            ("zmax", self.zmax_var),
+            ("delta", self.delta_var),
+        ]
+        for i, (label, var) in enumerate(labels):
+            ttk.Label(helper_frame, text=label+":").grid(row=i, column=0, sticky="e", padx=5, pady=2)
+            ttk.Entry(helper_frame, textvariable=var, width=10).grid(row=i, column=1, padx=5, pady=2)
+
+        ttk.Label(helper_frame, text="mode:").grid(row=len(labels), column=0, sticky="e", padx=5, pady=2)
+        mode_combo = ttk.Combobox(
+            helper_frame,
+            values=["uniform", "ratio"],
+            state="readonly",
+            textvariable=self.mode_var,
+            width=10,
+        )
+        mode_combo.grid(row=len(labels), column=1, padx=5, pady=2)
+
+        ttk.Button(helper_frame, text="Compute", command=self.compute_bins).grid(
+            row=len(labels)+1, column=0, columnspan=2, pady=(10, 5)
+        )
+
+        self.output_box = ScrolledText(helper_frame, wrap=tk.WORD, height=10)
+        self.output_box.grid(row=len(labels)+2, column=0, columnspan=2, pady=5, sticky="nsew")
+        helper_frame.rowconfigure(len(labels)+2, weight=1)
+        helper_frame.columnconfigure(1, weight=1)
+
+    # ------------------------------------------------------------------
+    def compute_bins(self) -> None:
+        """Compute mesh bins using provided extents and update the output box."""
+
+        try:
+            xmin = float(self.xmin_var.get())
+            xmax = float(self.xmax_var.get())
+            ymin = float(self.ymin_var.get())
+            ymax = float(self.ymax_var.get())
+            zmin = float(self.zmin_var.get())
+            zmax = float(self.zmax_var.get())
+            delta = float(self.delta_var.get())
+            result = plan_mesh(
+                xmin=xmin,
+                xmax=xmax,
+                ymin=ymin,
+                ymax=ymax,
+                zmin=zmin,
+                zmax=zmax,
+                delta=delta,
+                mode=self.mode_var.get(),
+            )
+        except Exception as e:  # pragma: no cover - GUI interaction
+            Messagebox.showerror("Bin Helper Error", str(e))
+            return
+
+        self.output_box.delete("1.0", tk.END)
+        self.output_box.insert("1.0", json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
- add Mesh Tally tab to the GUI
- include Bin Helper UI for computing mesh bin counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16256d8588324bf8f77ff04d419d6