### PR TITLE
Add origin/count-based mesh extent option

### DIFF
--- a/tests/test_mesh_bins_helper.py
+++ b/tests/test_mesh_bins_helper.py
@@ -1,4 +1,6 @@
-from mesh_bins_helper import plan_mesh_from_origin
+import pytest
+
+from mesh_bins_helper import plan_mesh_from_origin, plan_mesh_from_origin_counts
 
 def test_plan_mesh_from_origin_uniform():
     origin = (0.0, 0.0, 0.0)
@@ -12,3 +14,16 @@ def test_plan_mesh_from_origin_uniform():
     assert len(edges["x"]) == 25
     assert edges["x"][0] == origin[0]
     assert edges["x"][-1] == 6.0
+
+
+def test_plan_mesh_from_origin_counts_uniform():
+    origin = (0.0, 0.0, 0.0)
+    result = plan_mesh_from_origin_counts(origin, 24, 16, 12, delta=0.25)
+    ext = result["extents"]
+    assert ext["xmax"] == pytest.approx(6.0)
+    assert ext["ymax"] == pytest.approx(4.0)
+    assert ext["zmax"] == pytest.approx(3.0)
+    data = result["result"]
+    assert data["iints"] == 24
+    assert data["jints"] == 16
+    assert data["kints"] == 12


### PR DESCRIPTION
## Summary
- support deriving mesh extents from origin and I/J/K counts
- expose new --iints/--jints/--kints CLI options
- test planning meshes from origin and counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1728157088324b702fe24ac987077