### PR TITLE
Remove origin handling from mesh helper

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -6,7 +6,7 @@ from typing import Any
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox
 
-from mesh_bins_helper import plan_mesh_from_origin
+from mesh_bins_helper import plan_mesh_from_mesh
 
 
 class MeshTallyView:
@@ -16,10 +16,7 @@ class MeshTallyView:
         self.app = app
         self.frame = parent
 
-        # Variables for bin helper inputs (origin & mesh extents)
-        self.origin_x_var = tk.StringVar()
-        self.origin_y_var = tk.StringVar()
-        self.origin_z_var = tk.StringVar()
+        # Variables for bin helper inputs (mesh extents)
         self.imesh_var = tk.StringVar()
         self.jmesh_var = tk.StringVar()
         self.kmesh_var = tk.StringVar()
@@ -35,11 +32,8 @@ class MeshTallyView:
         helper_frame = ttk.LabelFrame(self.frame, text="Bin Helper")
         helper_frame.pack(fill="both", expand=True, padx=10, pady=10)
 
-        # Grid for origin & IMESH/JMESH/KMESH entries
+        # Grid for IMESH/JMESH/KMESH entries
         labels = [
-            ("Origin X", self.origin_x_var),
-            ("Origin Y", self.origin_y_var),
-            ("Origin Z", self.origin_z_var),
             ("IMESH", self.imesh_var),
             ("JMESH", self.jmesh_var),
             ("KMESH", self.kmesh_var),
@@ -70,20 +64,14 @@ class MeshTallyView:
 
     # ------------------------------------------------------------------
     def compute_bins(self) -> None:
-        """Compute mesh bins using provided origin and IMESH/JMESH/KMESH."""
+        """Compute mesh bins using IMESH/JMESH/KMESH."""
 
         try:
-            origin = (
-                float(self.origin_x_var.get()),
-                float(self.origin_y_var.get()),
-                float(self.origin_z_var.get()),
-            )
             imesh = float(self.imesh_var.get())
             jmesh = float(self.jmesh_var.get())
             kmesh = float(self.kmesh_var.get())
             delta = float(self.delta_var.get())
-            result = plan_mesh_from_origin(
-                origin=origin,
+            result = plan_mesh_from_mesh(
                 imesh=imesh,
                 jmesh=jmesh,
                 kmesh=kmesh,

--- a/tests/test_mesh_bins_helper.py
+++ b/tests/test_mesh_bins_helper.py
@@ -1,10 +1,10 @@
 import pytest
 
-from mesh_bins_helper import plan_mesh_from_origin, plan_mesh_from_origin_counts
+from mesh_bins_helper import plan_mesh_from_mesh, plan_mesh_from_counts
 
-def test_plan_mesh_from_origin_uniform():
-    origin = (0.0, 0.0, 0.0)
-    result = plan_mesh_from_origin(origin, 6.0, 4.0, 3.0, delta=0.25)
+
+def test_plan_mesh_from_mesh_uniform():
+    result = plan_mesh_from_mesh(6.0, 4.0, 3.0, delta=0.25)
     data = result["result"]
     assert data["iints"] == 24
     assert data["jints"] == 16
@@ -12,13 +12,12 @@ def test_plan_mesh_from_origin_uniform():
     # ensure edges are computed
     edges = result["edges"]
     assert len(edges["x"]) == 25
-    assert edges["x"][0] == origin[0]
+    assert edges["x"][0] == 0.0
     assert edges["x"][-1] == 6.0
 
 
-def test_plan_mesh_from_origin_counts_uniform():
-    origin = (0.0, 0.0, 0.0)
-    result = plan_mesh_from_origin_counts(origin, 24, 16, 12, delta=0.25)
+def test_plan_mesh_from_counts_uniform():
+    result = plan_mesh_from_counts(24, 16, 12, delta=0.25)
     ext = result["extents"]
     assert ext["xmax"] == pytest.approx(6.0)
     assert ext["ymax"] == pytest.approx(4.0)


### PR DESCRIPTION
## Summary
- remove origin arguments from mesh bin helpers and CLI
- simplify GUI bin helper to rely on IMESH/JMESH/KMESH only
- update tests for new origin-less helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17876f5f88324ad89ab2e01f6a467