### PR TITLE
Handle MCNP mesh tally output files

### DIFF
--- a/run_packages.py
+++ b/run_packages.py
@@ -92,7 +92,7 @@ def calculate_estimated_time(ctme_minutes: float, num_files: int, jobs: int) -> 
 def is_valid_input_file(filename: str) -> bool:
     """Return ``True`` if ``filename`` does not end with known output suffixes."""
 
-    invalid_suffixes = {"o", "r", "l", "m", "c"}
+    invalid_suffixes = {"o", "r", "l", "m", "c", "msht"}
     return not any(filename.endswith(s) for s in invalid_suffixes)
 
 
@@ -115,7 +115,7 @@ def validate_input_folder(folder: str | Path) -> bool:
 def gather_input_files(folder: str | Path, mode: str) -> List[str]:
     """Return a list of MCNP input files for the given folder and mode."""
 
-    known_output_suffixes = {"o", "r", "l", "c"}
+    known_output_suffixes = {"o", "r", "l", "c", "msht"}
     if mode == "single":
         return []  # single file handled via GUI
     folder = resolve_path(folder)
@@ -138,7 +138,7 @@ def check_existing_outputs(inp_files: Iterable[str], folder: str | Path) -> List
     existing_outputs: List[str] = []
     for inp in inp_files:
         base = Path(inp).name
-        for suffix in ("o", "r", "c"):
+        for suffix in ("o", "r", "c", "msht"):
             out_name = folder / f"{base}{suffix}"
             if out_name.exists():
                 existing_outputs.append(str(out_name))

--- a/tests/test_run_packages.py
+++ b/tests/test_run_packages.py
@@ -37,6 +37,7 @@ def test_gather_input_files_filters_correctly(tmp_path):
     # Files that should be ignored
     (tmp_path / "outputo").write_text("")  # extensionless ending with o
     (tmp_path / "resultr").write_text("")  # extensionless ending with r
+    (tmp_path / "meshmsht").write_text("")  # extensionless ending with msht
     (tmp_path / "ignored.txt").write_text("")  # has extension
     (tmp_path / "ignored.o").write_text("")  # known output extension
     (tmp_path / ".DS_Store").write_text("")  # hidden file
@@ -45,6 +46,15 @@ def test_gather_input_files_filters_correctly(tmp_path):
     assert set(files) == {str(inp1), str(inp2), str(keep)}
     # single mode should ignore folder
     assert run_packages.gather_input_files(tmp_path, "single") == []
+
+
+def test_check_existing_outputs_includes_msht(tmp_path):
+    inp = tmp_path / "case"
+    inp.write_text("")
+    msht = tmp_path / "casemsht"
+    msht.write_text("")
+    outputs = run_packages.check_existing_outputs([str(inp)], tmp_path)
+    assert str(msht) in outputs
 
 
 def test_run_mcnp_missing_executable_logs_error(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Summary
- Treat `msht` files as MCNP output artifacts
- Ensure mesh tally outputs are removed or backed up along with other outputs
- Test detection of `msht` files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c181a5ab088324a225f1658620e252