### PR TITLE
refactor: centralize configuration helpers

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -1,4 +1,3 @@
-import json
 import os
 import sys
 import logging
@@ -8,6 +7,12 @@ from tkinter.scrolledtext import ScrolledText
 
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox
+
+from config_utils import (
+    PROJECT_SETTINGS_PATH,
+    load_settings,
+    save_settings,
+)
 
 try:
     import tkinterdnd2 as tkdnd
@@ -82,7 +87,7 @@ class He3PlotterApp:
         self.tkdnd = tkdnd
 
         # Paths and settings
-        self.settings_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+        self.settings_path = str(PROJECT_SETTINGS_PATH)
         self.base_dir = self.load_mcnp_path()
         if not self.base_dir:
             self.base_dir = filedialog.askdirectory(
@@ -100,47 +105,19 @@ class He3PlotterApp:
                 )
                 sys.exit(1)
             else:
-                try:
-                    with open(self.settings_path, "w") as f:
-                        json.dump({"MY_MCNP_PATH": self.base_dir}, f)
-                except Exception:
-                    pass
+                save_settings({"MY_MCNP_PATH": self.base_dir})
 
-        # Load persisted user settings
-        if os.path.exists(self.settings_path):
-            try:
-                with open(self.settings_path, "r") as f:
-                    settings = json.load(f)
-                default_jobs = settings.get("default_jobs", 3)
-                self.default_jobs_var = tk.IntVar(value=default_jobs)
-                self.mcnp_jobs_var = tk.IntVar(value=default_jobs)
-                self.dark_mode_var = tk.BooleanVar(value=settings.get("dark_mode", False))
-                self.save_csv_var = tk.BooleanVar(value=settings.get("save_csv", True))
-                self.neutron_yield = tk.StringVar(value=settings.get("neutron_yield", "single"))
-                self.theme_var = tk.StringVar(value=settings.get("theme", "flatly"))
-                self.file_tag_var = tk.StringVar(value=settings.get("file_tag", ""))
-                self.plot_ext_var = tk.StringVar(value=settings.get("plot_ext", "pdf"))
-                self.show_fig_heading_var = tk.BooleanVar(value=settings.get("show_fig_heading", True))
-            except Exception:
-                self.default_jobs_var = tk.IntVar(value=3)
-                self.mcnp_jobs_var = tk.IntVar(value=3)
-                self.dark_mode_var = tk.BooleanVar(value=False)
-                self.save_csv_var = tk.BooleanVar(value=True)
-                self.neutron_yield = tk.StringVar(value="single")
-                self.theme_var = tk.StringVar(value="flatly")
-                self.file_tag_var = tk.StringVar(value="")
-                self.plot_ext_var = tk.StringVar(value="pdf")
-                self.show_fig_heading_var = tk.BooleanVar(value=True)
-        else:
-            self.default_jobs_var = tk.IntVar(value=3)
-            self.mcnp_jobs_var = tk.IntVar(value=3)
-            self.dark_mode_var = tk.BooleanVar(value=False)
-            self.save_csv_var = tk.BooleanVar(value=True)
-            self.neutron_yield = tk.StringVar(value="single")
-            self.theme_var = tk.StringVar(value="flatly")
-            self.file_tag_var = tk.StringVar(value="")
-            self.plot_ext_var = tk.StringVar(value="pdf")
-            self.show_fig_heading_var = tk.BooleanVar(value=True)
+        settings = load_settings()
+        default_jobs = settings.get("default_jobs", 3)
+        self.default_jobs_var = tk.IntVar(value=default_jobs)
+        self.mcnp_jobs_var = tk.IntVar(value=default_jobs)
+        self.dark_mode_var = tk.BooleanVar(value=settings.get("dark_mode", False))
+        self.save_csv_var = tk.BooleanVar(value=settings.get("save_csv", True))
+        self.neutron_yield = tk.StringVar(value=settings.get("neutron_yield", "single"))
+        self.theme_var = tk.StringVar(value=settings.get("theme", "flatly"))
+        self.file_tag_var = tk.StringVar(value=settings.get("file_tag", ""))
+        self.plot_ext_var = tk.StringVar(value=settings.get("plot_ext", "pdf"))
+        self.show_fig_heading_var = tk.BooleanVar(value=settings.get("show_fig_heading", True))
 
         # Shared variables for runner view
         self.mcnp_folder_var = tk.StringVar()
@@ -172,12 +149,10 @@ class He3PlotterApp:
 
     # ------------------------------------------------------------------
     def load_mcnp_path(self):
-        try:
-            if os.path.exists(self.settings_path):
-                with open(self.settings_path, "r") as f:
-                    return json.load(f).get("MY_MCNP_PATH")
-        except Exception:
-            pass
+        settings = load_settings()
+        path = settings.get("MY_MCNP_PATH")
+        if path:
+            return path
         fallback = os.path.expanduser("~/Documents/MCNP/MY_MCNP")
         if os.path.exists(fallback):
             return fallback

--- a/config_utils.py
+++ b/config_utils.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+# Paths used for storing configuration
+PROJECT_SETTINGS_PATH = Path(__file__).resolve().parent / "config.json"
+HOME_SETTINGS_PATH = Path.home() / ".mcnp_tools_settings.json"
+
+
+def load_settings() -> dict:
+    """Load settings from the project or user configuration file.
+
+    Settings are read with the following precedence:
+
+    1. Project-local ``config.json``
+    2. Legacy user config ``~/.mcnp_tools_settings.json``
+    """
+    for path in (PROJECT_SETTINGS_PATH, HOME_SETTINGS_PATH):
+        try:
+            if path.exists():
+                with open(path, "r") as f:
+                    return json.load(f)
+        except Exception:
+            # Ignore malformed files and fall back to next option
+            pass
+    return {}
+
+
+def save_settings(data: dict) -> None:
+    """Persist ``data`` to the project ``config.json`` file.
+
+    Existing settings are merged so that only provided keys are updated.
+    """
+    try:
+        if PROJECT_SETTINGS_PATH.exists():
+            with open(PROJECT_SETTINGS_PATH, "r") as f:
+                existing = json.load(f)
+        else:
+            existing = {}
+        existing.update(data)
+        with open(PROJECT_SETTINGS_PATH, "w") as f:
+            json.dump(existing, f)
+    except Exception:
+        # Silently ignore I/O errors to avoid disrupting the caller
+        pass

--- a/run_packages.py
+++ b/run_packages.py
@@ -2,7 +2,6 @@
 
 import concurrent.futures
 import datetime
-import json
 import logging
 import os
 import re
@@ -10,6 +9,8 @@ import shutil
 import subprocess
 from pathlib import Path
 from typing import Any, Iterable, List, Optional
+
+from config_utils import load_settings
 
 logger = logging.getLogger(__name__)
 
@@ -36,23 +37,7 @@ following precedence:
 This keeps backward compatibility while ensuring the GUI selection is honored.
 """
 
-# Try project-local config first (written by GUI)
-PROJECT_SETTINGS_PATH = Path(__file__).resolve().parent / "config.json"
-# Legacy per-user settings file for backward compatibility
-HOME_SETTINGS_PATH = Path.home() / ".mcnp_tools_settings.json"
-
-def _load_settings() -> dict:
-    for path in (PROJECT_SETTINGS_PATH, HOME_SETTINGS_PATH):
-        try:
-            if path.exists():
-                with open(path, "r") as f:
-                    return json.load(f)
-        except Exception:
-            # Ignore malformed files and continue to next fallback
-            pass
-    return {}
-
-settings = _load_settings()
+settings = load_settings()
 
 # Centralised base directory used for all path construction. Priority is given
 # to environment variables so installations can be relocated without editing
@@ -75,7 +60,7 @@ def get_mcnp_executable() -> Path:
     This is resolved dynamically so changes to environment variables or
     configuration files after import time are respected.
     """
-    settings = _load_settings()
+    settings = load_settings()
     root = os.getenv("MY_MCNP") or settings.get("MY_MCNP_PATH")
     if root:
         return Path(root).expanduser() / "MCNP_CODE" / "bin" / "mcnp6"


### PR DESCRIPTION
## Summary
- add `config_utils` module with reusable `load_settings` and `save_settings`
- refactor runner and GUI to consume new helpers and share configuration loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1876e79a08324938d38d477abe20f