### PR TITLE
Add MSHT mesh tally parser

### DIFF
--- a/msht_parser.py
+++ b/msht_parser.py
@@ -1,0 +1,94 @@
+"""Parser for MCNP mesh tally (.msht) files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+import pandas as pd
+
+
+def _to_floats(parts: Iterable[str]) -> list[float]:
+    """Convert an iterable of strings to floats.
+
+    Parameters
+    ----------
+    parts : Iterable[str]
+        String tokens to convert.
+
+    Returns
+    -------
+    list[float]
+        Converted float values.
+
+    Raises
+    ------
+    ValueError
+        If any token cannot be converted to ``float``.
+    """
+
+    try:
+        return [float(p) for p in parts]
+    except ValueError as exc:  # pragma: no cover - defensive, exercised via parse_msht
+        raise ValueError("non-numeric data encountered") from exc
+
+
+def parse_msht(path: str | Path) -> pd.DataFrame:
+    """Parse an MSHT mesh tally file into a :class:`pandas.DataFrame`.
+
+    The parser searches for the line starting with ``"X         Y         Z     Result"``
+    which marks the beginning of the mesh tally table. Subsequent non-blank
+    lines are read until another blank line or a line containing non-numeric
+    data is encountered. Each valid record is split into seven float columns
+    corresponding to ``x``, ``y``, ``z``, ``result``, ``rel_error``, ``volume``
+    and ``result_vol``.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the ``.msht`` file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``['x', 'y', 'z', 'result', 'rel_error',
+        'volume', 'result_vol']``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If the file is malformed or does not contain a table.
+    """
+
+    path = Path(path)
+    try:
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except FileNotFoundError:
+        raise
+
+    header = "X         Y         Z     Result"
+    try:
+        start = next(i for i, line in enumerate(lines) if line.startswith(header))
+    except StopIteration as exc:
+        raise ValueError("MSHT table header not found") from exc
+
+    data: list[list[float]] = []
+    for raw_line in lines[start + 1:]:
+        if not raw_line.strip():
+            break
+        parts = raw_line.split()
+        # Stop at the first non-numeric record
+        try:
+            floats = _to_floats(parts)
+        except ValueError:
+            break
+        if len(floats) != 7:
+            raise ValueError("expected 7 columns in MSHT data line")
+        data.append(floats)
+
+    if not data:
+        raise ValueError("no data lines found in MSHT file")
+
+    columns = ["x", "y", "z", "result", "rel_error", "volume", "result_vol"]
+    return pd.DataFrame(data, columns=columns)

--- a/tests/test_msht_parser.py
+++ b/tests/test_msht_parser.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pandas.testing as pdt
+from pathlib import Path
+
+from msht_parser import parse_msht
+
+
+def test_parse_msht(tmp_path: Path) -> None:
+    content = (
+        "Some preamble\n"
+        "X         Y         Z     Result    Rel Error   Volume    Result*Volume\n"
+        "1.0 2.0 3.0 4.0 0.5 6.0 24.0\n"
+        "2.0 3.0 4.0 5.0 0.6 7.0 35.0\n"
+        "\n"
+        "Other text\n"
+    )
+    file_path = tmp_path / "sample.msht"
+    file_path.write_text(content, encoding="utf-8")
+
+    df = parse_msht(file_path)
+    expected = pd.DataFrame(
+        [
+            [1.0, 2.0, 3.0, 4.0, 0.5, 6.0, 24.0],
+            [2.0, 3.0, 4.0, 5.0, 0.6, 7.0, 35.0],
+        ],
+        columns=["x", "y", "z", "result", "rel_error", "volume", "result_vol"],
+    )
+
+    pdt.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Summary
- add `msht_parser.parse_msht` to read mesh tally tables into a DataFrame
- test parsing logic against a sample MSHT snippet

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18b0ce8f4832480ca15e1f3e5ecf9