### PR TITLE
Add accessor for mesh tally DataFrame

### DIFF
--- a/docs/mesh_dataframe_schema.md
+++ b/docs/mesh_dataframe_schema.md
@@ -1,0 +1,18 @@
+# Mesh Tally DataFrame Schema
+
+Mesh tally files parsed with `msht_parser.parse_msht` or loaded through
+`MeshTallyView` produce a `pandas.DataFrame` with the following columns:
+
+| Column      | Type  | Description                       |
+|-------------|-------|-----------------------------------|
+| `x`         | float | X-coordinate of the mesh element |
+| `y`         | float | Y-coordinate of the mesh element |
+| `z`         | float | Z-coordinate of the mesh element |
+| `result`    | float | Tally result value               |
+| `rel_error` | float | Relative error of the result     |
+| `volume`    | float | Volume of the voxel              |
+| `result_vol`| float | `result * volume`                |
+
+All values are represented as floating point numbers. Future analysis
+functions can rely on these column names and types when consuming mesh
+tally data.

--- a/mesh_view.py
+++ b/mesh_view.py
@@ -3,6 +3,8 @@ from tkinter.filedialog import asksaveasfilename
 from tkinter.scrolledtext import ScrolledText
 from typing import Any
 
+import pandas as pd
+
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox
 
@@ -25,7 +27,7 @@ class MeshTallyView:
         self.delta_var = tk.StringVar()
         self.mode_var = tk.StringVar(value="uniform")
 
-        self.msht_df = None
+        self.msht_df: pd.DataFrame | None = None
 
         self.build()
 
@@ -146,10 +148,32 @@ class MeshTallyView:
         self.output_box.insert("1.0", preview)
 
     # ------------------------------------------------------------------
+    def get_mesh_dataframe(self) -> pd.DataFrame:
+        """Return the parsed mesh tally data.
+
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame with columns ``['x', 'y', 'z', 'result', 'rel_error',
+            'volume', 'result_vol']``.
+
+        Raises
+        ------
+        ValueError
+            If no mesh tally has been loaded yet.
+        """
+
+        if self.msht_df is None:
+            raise ValueError("No MSHT data loaded")
+        return self.msht_df
+
+    # ------------------------------------------------------------------
     def save_msht_csv(self) -> None:
         """Save the loaded MSHT DataFrame to a CSV file."""
 
-        if self.msht_df is None:
+        try:
+            df = self.get_mesh_dataframe()
+        except ValueError:
             Messagebox.showerror("Save CSV Error", "No MSHT data loaded")
             return
         try:
@@ -160,6 +184,6 @@ class MeshTallyView:
             )
             if not path:
                 return
-            self.msht_df.to_csv(path, index=False)
+            df.to_csv(path, index=False)
         except Exception as exc:  # pragma: no cover - GUI interaction
             Messagebox.showerror("Save CSV Error", str(exc))

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import mesh_view
@@ -44,7 +45,7 @@ def test_load_msht_and_save_csv(tmp_path, monkeypatch):
         ],
         columns=["x", "y", "z", "result", "rel_error", "volume", "result_vol"],
     )
-    pdt.assert_frame_equal(view.msht_df, expected)
+    pdt.assert_frame_equal(view.get_mesh_dataframe(), expected)
     assert "1.0" in view.output_box.get("1.0", "end")
 
     csv_path = tmp_path / "out.csv"
@@ -63,5 +64,6 @@ def test_load_msht_parse_error(monkeypatch):
         called["msg"] = (title, message)
     monkeypatch.setattr(mesh_view.Messagebox, "showerror", fake_error, raising=False)
     view.load_msht()
-    assert view.msht_df is None
+    with pytest.raises(ValueError):
+        view.get_mesh_dataframe()
     assert called["msg"][0] == "MSHT Load Error"


### PR DESCRIPTION
## Summary
- add `MeshTallyView.get_mesh_dataframe` for accessing parsed mesh tally data
- reuse `get_mesh_dataframe` when saving CSVs and update tests
- document mesh tally DataFrame schema for analysis functions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18e788e1c83249000a1b79bd05ac1