### PR TITLE
Fix Messagebox usage and improve MSHT header parsing

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -96,7 +96,7 @@ class He3PlotterApp:
                 mustexist=True,
             )
             if not self.base_dir:
-                Messagebox.showerror(
+                Messagebox.show_error(
                     "Missing MY_MCNP Directory",
                     (
                         "You must select the folder that contains the MCNP_CODE directory and your simulation folders.\n\n"

--- a/mesh_view.py
+++ b/mesh_view.py
@@ -110,7 +110,7 @@ class MeshTallyView:
                 mode=self.mode_var.get(),
             )
         except Exception as e:  # pragma: no cover - GUI interaction
-            Messagebox.showerror("Bin Helper Error", str(e))
+            Messagebox.show_error("Bin Helper Error", str(e))
             return
 
         self.output_box.delete("1.0", tk.END)
@@ -135,7 +135,7 @@ class MeshTallyView:
                 return
             df = msht_parser.parse_msht(path)
         except Exception as exc:  # pragma: no cover - GUI interaction
-            Messagebox.showerror("MSHT Load Error", str(exc))
+            Messagebox.show_error("MSHT Load Error", str(exc))
             return
 
         self.msht_df = df
@@ -143,7 +143,7 @@ class MeshTallyView:
         try:
             preview = df.head().to_string(index=False)
         except Exception as exc:  # pragma: no cover - defensive
-            Messagebox.showerror("MSHT Preview Error", str(exc))
+            Messagebox.show_error("MSHT Preview Error", str(exc))
             preview = ""
         self.output_box.insert("1.0", preview)
 
@@ -174,7 +174,7 @@ class MeshTallyView:
         try:
             df = self.get_mesh_dataframe()
         except ValueError:
-            Messagebox.showerror("Save CSV Error", "No MSHT data loaded")
+            Messagebox.show_error("Save CSV Error", "No MSHT data loaded")
             return
         try:
             path = asksaveasfilename(
@@ -186,4 +186,4 @@ class MeshTallyView:
                 return
             df.to_csv(path, index=False)
         except Exception as exc:  # pragma: no cover - GUI interaction
-            Messagebox.showerror("Save CSV Error", str(exc))
+            Messagebox.show_error("Save CSV Error", str(exc))

--- a/msht_parser.py
+++ b/msht_parser.py
@@ -67,9 +67,18 @@ def parse_msht(path: str | Path) -> pd.DataFrame:
     except FileNotFoundError:
         raise
 
-    header = "X         Y         Z     Result"
+    # The header line that marks the start of the tally table can vary in
+    # spacing or capitalization between MCNP versions.  Instead of matching the
+    # entire string exactly, split the line into tokens and compare the first
+    # four fields case-insensitively.  This makes the parser resilient to
+    # leading whitespace or different column spacing.
+    header_tokens = ["x", "y", "z", "result"]
     try:
-        start = next(i for i, line in enumerate(lines) if line.startswith(header))
+        start = next(
+            i
+            for i, line in enumerate(lines)
+            if [t.lower() for t in line.split()[:4]] == header_tokens
+        )
     except StopIteration as exc:
         raise ValueError("MSHT table header not found") from exc
 

--- a/settings_view.py
+++ b/settings_view.py
@@ -123,12 +123,12 @@ class SettingsView:
     def reset_settings(self) -> None:
         """Reset settings to defaults and exit the application."""
 
-        if Messagebox.askyesno("Reset Settings", "Are you sure you want to reset all settings to default?"):
+        if Messagebox.yesno("Reset Settings", "Are you sure you want to reset all settings to default?"):
             try:
                 settings_file = Path(self.app.settings_path)
                 if settings_file.exists():
                     settings_file.unlink()
-                Messagebox.showinfo("Reset Complete", "Settings reset to default. Please restart the application.")
+                Messagebox.show_info("Reset Complete", "Settings reset to default. Please restart the application.")
                 self.app.root.quit()
             except Exception as e:
-                Messagebox.showerror("Error", f"Failed to reset settings: {e}")
+                Messagebox.show_error("Error", f"Failed to reset settings: {e}")

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -62,7 +62,7 @@ def test_load_msht_parse_error(monkeypatch):
     called = {}
     def fake_error(title, message):
         called["msg"] = (title, message)
-    monkeypatch.setattr(mesh_view.Messagebox, "showerror", fake_error, raising=False)
+    monkeypatch.setattr(mesh_view.Messagebox, "show_error", fake_error, raising=False)
     view.load_msht()
     with pytest.raises(ValueError):
         view.get_mesh_dataframe()

--- a/tests/test_msht_parser.py
+++ b/tests/test_msht_parser.py
@@ -27,3 +27,21 @@ def test_parse_msht(tmp_path: Path) -> None:
     )
 
     pdt.assert_frame_equal(df, expected)
+
+
+def test_parse_msht_header_flexible(tmp_path: Path) -> None:
+    """Header detection should ignore spacing and case."""
+    content = (
+        "Random text\n"
+        "   x    y    z    result    rel error   volume    result*volume\n"
+        "1 2 3 4 0.5 6 24\n"
+    )
+    file_path = tmp_path / "sample.msht"
+    file_path.write_text(content, encoding="utf-8")
+
+    df = parse_msht(file_path)
+    expected = pd.DataFrame(
+        [[1.0, 2.0, 3.0, 4.0, 0.5, 6.0, 24.0]],
+        columns=["x", "y", "z", "result", "rel_error", "volume", "result_vol"],
+    )
+    pdt.assert_frame_equal(df, expected)


### PR DESCRIPTION
## Summary
- make MSHT parser detect header tokens case-insensitively to support varied spacing
- use correct ttkbootstrap Messagebox API (show_error/show_info/yesno)
- add regression test for flexible MSHT header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18f943430832497eb9c178ac2796c