### PR TITLE
Add dose calculator view

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -23,6 +23,7 @@ from analysis_view import AnalysisView
 from runner_view import RunnerView
 from settings_view import SettingsView
 from mesh_view import MeshTallyView
+from dose_view import DoseView
 import logging_config
 
 # Module-level logger for this module
@@ -166,18 +167,21 @@ class He3PlotterApp:
         self.runner_tab = ttk.Frame(self.tabs)
         self.analysis_tab = ttk.Frame(self.tabs)
         self.mesh_tab = ttk.Frame(self.tabs)
+        self.dose_tab = ttk.Frame(self.tabs)
         self.help_tab = ttk.Frame(self.tabs)
         self.settings_tab = ttk.Frame(self.tabs)
 
         self.tabs.add(self.runner_tab, text="Run MCNP")
         self.tabs.add(self.analysis_tab, text="Analysis")
         self.tabs.add(self.mesh_tab, text="Mesh Tally")
+        self.tabs.add(self.dose_tab, text="Dose Calc")
         self.tabs.add(self.help_tab, text="How to Use")
         self.tabs.add(self.settings_tab, text="Settings")
 
         self.runner_view = RunnerView(self, self.runner_tab)
         self.analysis_view = AnalysisView(self, self.analysis_tab)
         self.mesh_view = MeshTallyView(self, self.mesh_tab)
+        self.dose_view = DoseView(self, self.dose_tab)
         self.settings_view = SettingsView(self, self.settings_tab)
 
         help_label = tk.Label(self.help_tab, text="How to Use MCNP Tools", font=("Arial", 14, "bold"))

--- a/analysis_view.py
+++ b/analysis_view.py
@@ -164,7 +164,7 @@ class AnalysisView:
 
         output_frame = ttk.LabelFrame(self.frame, text="Output Console")
         output_frame.pack(fill="both", expand=True, padx=10, pady=5)
-        self.output_console = ScrolledText(output_frame, wrap=tk.WORD, height=8)
+        self.output_console = ScrolledText(output_frame, wrap=tk.WORD, height=6)
         self.output_console.pack(fill="both", expand=True)
 
         file_frame = ttk.LabelFrame(self.frame, text="Saved Plots")

--- a/dose_view.py
+++ b/dose_view.py
@@ -1,0 +1,127 @@
+import tkinter as tk
+from typing import Any
+
+import ttkbootstrap as ttk
+
+
+class DoseView:
+    """Simple calculator to convert a result value into dose."""
+
+    def __init__(self, app: Any, parent: tk.Widget) -> None:
+        self.app = app
+        self.frame = parent
+
+        self.result_var = tk.StringVar()
+        self.dose_var = tk.StringVar()
+        self.source_vars = {
+            "Small tank (1.25e6)": tk.BooleanVar(),
+            "Big tank (2.5e6)": tk.BooleanVar(),
+            "Graphite stack (7.5e6)": tk.BooleanVar(),
+        }
+        self.custom_var = tk.BooleanVar()
+        self.custom_value_var = tk.StringVar()
+
+        self.build()
+
+    # ------------------------------------------------------------------
+    def build(self) -> None:
+        """Build the dose calculator widgets."""
+
+        container = ttk.LabelFrame(self.frame, text="Dose Calculator")
+        container.pack(fill="x", padx=10, pady=10)
+
+        entry_frame = ttk.Frame(container)
+        entry_frame.pack(fill="x", padx=10, pady=5)
+        ttk.Label(entry_frame, text="Result:").pack(side="left")
+        ttk.Entry(entry_frame, textvariable=self.result_var, width=15).pack(
+            side="left", padx=5
+        )
+
+        source_frame = ttk.LabelFrame(container, text="Source Emission Rate")
+        source_frame.pack(fill="x", padx=10, pady=5)
+        for label, var in self.source_vars.items():
+            ttk.Checkbutton(source_frame, text=label, variable=var).pack(
+                anchor="w", padx=10
+            )
+
+        custom_frame = ttk.Frame(source_frame)
+        custom_frame.pack(anchor="w", padx=10)
+        ttk.Checkbutton(custom_frame, text="Other", variable=self.custom_var).pack(
+            side="left"
+        )
+        vcmd = (self.frame.register(self._validate_float), "%P")
+        ttk.Entry(
+            custom_frame,
+            textvariable=self.custom_value_var,
+            width=10,
+            validate="key",
+            validatecommand=vcmd,
+        ).pack(side="left", padx=5)
+
+        button_frame = ttk.Frame(container)
+        button_frame.pack(pady=5)
+        ttk.Button(button_frame, text="Calculate", command=self.calculate_dose).pack(
+            side="left", padx=5
+        )
+        ttk.Button(button_frame, text="Clear", command=self.clear).pack(
+            side="left", padx=5
+        )
+
+        output_frame = ttk.Frame(container)
+        output_frame.pack(fill="x", padx=10, pady=5)
+        ttk.Label(output_frame, text="Dose (\u00b5Sv/h):").pack(side="left")
+        ttk.Entry(output_frame, textvariable=self.dose_var, state="readonly", width=25).pack(
+            side="left", padx=5
+        )
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        """Reset all fields in the calculator."""
+
+        self.result_var.set("")
+        self.dose_var.set("")
+        for var in self.source_vars.values():
+            var.set(False)
+        self.custom_var.set(False)
+        self.custom_value_var.set("")
+
+    def _validate_float(self, P: str) -> bool:  # pragma: no cover - UI validation
+        if P == "":
+            return True
+        try:
+            float(P)
+            return True
+        except ValueError:
+            return False
+
+    # ------------------------------------------------------------------
+    def calculate_dose(self) -> None:
+        """Compute dose from the provided result and selected sources."""
+
+        try:
+            result_val = float(self.result_var.get())
+        except ValueError:
+            self.app.log("Invalid result value.")
+            return
+
+        source_map = {
+            "Small tank (1.25e6)": 1.25e6,
+            "Big tank (2.5e6)": 2.5e6,
+            "Graphite stack (7.5e6)": 7.5e6,
+        }
+        total_rate = sum(
+            val for label, val in source_map.items() if self.source_vars[label].get()
+        )
+        if self.custom_var.get():
+            try:
+                total_rate += float(self.custom_value_var.get())
+            except ValueError:
+                self.app.log("Invalid custom source value.")
+                return
+        if total_rate == 0:
+            self.app.log("No neutron sources selected. Please select at least one.")
+            return
+
+        dose = result_val * total_rate * 3600 * 1e6
+        self.dose_var.set(f"{dose:.3e}")
+        self.app.log(f"Calculated dose: {self.dose_var.get()} \u00b5Sv/h")

--- a/tests/test_dose_view.py
+++ b/tests/test_dose_view.py
@@ -1,0 +1,55 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+class DummyVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+class DummyApp:
+    def __init__(self):
+        self.logged = []
+
+    def log(self, message, level=None):
+        self.logged.append(message)
+
+
+def setup_view(monkeypatch):
+    ttk = types.ModuleType("ttkbootstrap")
+    monkeypatch.setitem(sys.modules, "ttkbootstrap", ttk)
+
+    import importlib
+    module = importlib.import_module("dose_view")
+    module = importlib.reload(module)
+
+    app = DummyApp()
+    dv = object.__new__(module.DoseView)
+    dv.app = app
+    dv.result_var = DummyVar("2.0")
+    dv.dose_var = DummyVar("")
+    dv.source_vars = {
+        "Small tank (1.25e6)": DummyVar(True),
+        "Big tank (2.5e6)": DummyVar(False),
+        "Graphite stack (7.5e6)": DummyVar(False),
+    }
+    dv.custom_var = DummyVar(True)
+    dv.custom_value_var = DummyVar("1e6")
+    return dv, app
+
+
+def test_calculate_dose(monkeypatch):
+    dv, app = setup_view(monkeypatch)
+    dv.calculate_dose()
+    expected = 2.0 * (1.25e6 + 1e6) * 3600 * 1e6
+    assert dv.dose_var.get() == f"{expected:.3e}"
+    assert any("Calculated dose" in msg for msg in app.logged)


### PR DESCRIPTION
## Summary
- add dose calculator tab with neutron source selection
- compute dose from results using emission rate
- shrink analysis output console

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c192c2acc483248701a7ee1e0d7bbf