### PR TITLE
Convert mesh tally results to dose with error propagation

### DIFF
--- a/docs/mesh_dataframe_schema.md
+++ b/docs/mesh_dataframe_schema.md
@@ -12,6 +12,8 @@ Mesh tally files parsed with `msht_parser.parse_msht` or loaded through
 | `rel_error` | float | Relative error of the result     |
 | `volume`    | float | Volume of the voxel              |
 | `result_vol`| float | `result * volume`                |
+| `dose`      | float | Dose converted from result       |
+| `dose_error`| float | Absolute error on `dose`         |
 
 All values are represented as floating point numbers. Future analysis
 functions can rely on these column names and types when consuming mesh

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -22,6 +22,7 @@ def make_view():
     view = mesh_view.MeshTallyView.__new__(mesh_view.MeshTallyView)
     view.output_box = DummyText()
     view.msht_df = None
+    view._get_total_rate = lambda: 1.0
     return view
 
 def test_load_msht_and_save_csv(tmp_path, monkeypatch):
@@ -38,12 +39,23 @@ def test_load_msht_and_save_csv(tmp_path, monkeypatch):
     monkeypatch.setattr(mesh_view, "select_file", lambda title='': str(file_path))
     view.load_msht()
 
+    factor = 3600 * 1e6
     expected = pd.DataFrame(
         [
-            [1.0, 2.0, 3.0, 4.0, 0.5, 6.0, 24.0],
-            [2.0, 3.0, 4.0, 5.0, 0.6, 7.0, 35.0],
+            [1.0, 2.0, 3.0, 4.0, 0.5, 6.0, 24.0, 4.0 * factor, 4.0 * factor * 0.5],
+            [2.0, 3.0, 4.0, 5.0, 0.6, 7.0, 35.0, 5.0 * factor, 5.0 * factor * 0.6],
         ],
-        columns=["x", "y", "z", "result", "rel_error", "volume", "result_vol"],
+        columns=[
+            "x",
+            "y",
+            "z",
+            "result",
+            "rel_error",
+            "volume",
+            "result_vol",
+            "dose",
+            "dose_error",
+        ],
     )
     pdt.assert_frame_equal(view.get_mesh_dataframe(), expected)
     assert "1.0" in view.output_box.get("1.0", "end")


### PR DESCRIPTION
## Summary
- allow selecting neutron source emission rate on mesh tally view
- compute dose and dose_error columns when loading MSHT files
- document new mesh DataFrame columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c195f27c088324bd949429aaeedd5a