### PR TITLE
Remove Dose Calc tab and resize mesh output

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -23,7 +23,6 @@ from analysis_view import AnalysisView
 from runner_view import RunnerView
 from settings_view import SettingsView
 from mesh_view import MeshTallyView
-from dose_view import DoseView
 import logging_config
 
 # Module-level logger for this module
@@ -167,21 +166,18 @@ class He3PlotterApp:
         self.runner_tab = ttk.Frame(self.tabs)
         self.analysis_tab = ttk.Frame(self.tabs)
         self.mesh_tab = ttk.Frame(self.tabs)
-        self.dose_tab = ttk.Frame(self.tabs)
         self.help_tab = ttk.Frame(self.tabs)
         self.settings_tab = ttk.Frame(self.tabs)
 
         self.tabs.add(self.runner_tab, text="Run MCNP")
         self.tabs.add(self.analysis_tab, text="Analysis")
         self.tabs.add(self.mesh_tab, text="Mesh Tally")
-        self.tabs.add(self.dose_tab, text="Dose Calc")
         self.tabs.add(self.help_tab, text="How to Use")
         self.tabs.add(self.settings_tab, text="Settings")
 
         self.runner_view = RunnerView(self, self.runner_tab)
         self.analysis_view = AnalysisView(self, self.analysis_tab)
         self.mesh_view = MeshTallyView(self, self.mesh_tab)
-        self.dose_view = DoseView(self, self.dose_tab)
         self.settings_view = SettingsView(self, self.settings_tab)
 
         help_label = tk.Label(self.help_tab, text="How to Use MCNP Tools", font=("Arial", 14, "bold"))

--- a/mesh_view.py
+++ b/mesh_view.py
@@ -45,7 +45,7 @@ class MeshTallyView:
         """Construct the mesh tally tab widgets."""
 
         helper_frame = ttk.LabelFrame(self.frame, text="Bin Helper")
-        helper_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        helper_frame.pack(fill="x", padx=10, pady=10)
 
         # First row: IMESH/JMESH/KMESH
         entries = [
@@ -87,9 +87,8 @@ class MeshTallyView:
         )
 
         # Output box for results
-        self.output_box = ScrolledText(helper_frame, wrap=tk.WORD, height=10)
-        self.output_box.grid(row=2, column=0, columnspan=6, pady=5, sticky="nsew")
-        helper_frame.rowconfigure(2, weight=1)
+        self.output_box = ScrolledText(helper_frame, wrap=tk.WORD, height=5)
+        self.output_box.grid(row=2, column=0, columnspan=6, pady=5, sticky="ew")
         for col in range(6):
             helper_frame.columnconfigure(col, weight=1)
 


### PR DESCRIPTION
## Summary
- Drop the unused Dose Calc tab from the main interface
- Shrink the mesh tally results box so it no longer expands vertically

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c197acd89083249d2f57492bea17f5