### PR TITLE
Handle interactive plotting backend for mesh view

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -4,6 +4,12 @@ from tkinter.scrolledtext import ScrolledText
 from typing import Any
 
 import pandas as pd
+import matplotlib
+
+try:  # Use TkAgg if available for interactive plots
+    matplotlib.use("TkAgg")
+except Exception:  # pragma: no cover - falls back to default backend
+    pass
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 - registers 3D proj
 


### PR DESCRIPTION
## Summary
- Try to use TkAgg backend for interactive mesh plots, falling back to default when unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19cb3215c832491539787d70bc6e8