### PR TITLE
Normalize 3D dose plot colours

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -11,6 +11,7 @@ try:  # Use TkAgg if available for interactive plots
 except Exception:  # pragma: no cover - falls back to default backend
     pass
 import matplotlib.pyplot as plt
+from matplotlib import colors
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 - registers 3D proj
 
 import ttkbootstrap as ttk
@@ -222,12 +223,15 @@ class MeshTallyView:
 
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")
+        max_dose = df["dose"].max()
+        norm = colors.Normalize(vmin=0, vmax=max_dose if max_dose != 0 else 1)
         sc = ax.scatter(
             df["x"],
             df["y"],
             df["z"],
             c=df["dose"],
             cmap="viridis",
+            norm=norm,
             marker="s",
             s=20,
         )

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -98,8 +98,10 @@ def test_plot_dose_map(monkeypatch):
     calls = {}
 
     class DummyAx:
-        def scatter(self, x, y, z, c, cmap, marker, s):
+        def scatter(self, x, y, z, c, cmap, marker, s, norm=None):
             calls["scatter"] = (list(x), list(y), list(z), list(c))
+            calls["norm_vmin"] = getattr(norm, "vmin", None)
+            calls["norm_vmax"] = getattr(norm, "vmax", None)
             return object()
 
         def set_xlabel(self, label):
@@ -125,5 +127,7 @@ def test_plot_dose_map(monkeypatch):
     view.plot_dose_map()
     assert calls["projection"] == "3d"
     assert calls["scatter"] == ([1.0], [2.0], [3.0], [4.0])
+    assert calls["norm_vmin"] == 0
+    assert calls["norm_vmax"] == 4.0
     assert calls["colorbar"] == "Dose (µSv/h)"
     assert calls["show"] is True


### PR DESCRIPTION
## Summary
- Normalise dose map scatter colours from 0 up to the maximum dose so hotspots are visible
- Cover new behaviour with updated unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19fe502788324b2466b38b681334f