### PR TITLE
Fix colorbar axes for mesh dose plot

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -243,7 +243,7 @@ class MeshTallyView:
         ax.set_zlabel("Z")
         sm = plt.cm.ScalarMappable(cmap=cmap, norm=colors.Normalize(vmin=0, vmax=max_dose))
         sm.set_array([])
-        fig.colorbar(sm, label="Dose (µSv/h)")
+        fig.colorbar(sm, ax=ax, label="Dose (µSv/h)")
         plt.show()
 
     # ------------------------------------------------------------------

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -119,7 +119,7 @@ def test_plot_dose_map(monkeypatch):
             calls["projection"] = projection
             return DummyAx()
 
-        def colorbar(self, sc, label=""):
+        def colorbar(self, sc, label="", ax=None):
             calls["colorbar"] = label
 
     monkeypatch.setattr(mesh_view.plt, "figure", lambda: DummyFig())


### PR DESCRIPTION
## Summary
- avoid ValueError when drawing dose map by binding colorbar to 3D axes
- adjust test stubs for new colorbar signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a382f5d88324a89e2330c0dfb547