### PR TITLE
Improve dose map transparency scaling

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -229,7 +229,8 @@ class MeshTallyView:
             max_dose = 1
         dose_norm = df["dose"] / max_dose
         colors_arr = cmap(dose_norm)
-        colors_arr[:, 3] = dose_norm
+        # Keep points with low dose visible by scaling alpha between 0.3 and 1.0
+        colors_arr[:, 3] = 0.3 + 0.7 * dose_norm
         ax.scatter(
             df["x"],
             df["y"],

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -129,7 +129,7 @@ def test_plot_dose_map(monkeypatch):
     assert calls["projection"] == "3d"
     assert calls["scatter"] == ([1.0, 2.0], [2.0, 3.0], [3.0, 4.0])
     alphas = [col[3] for col in calls["colors"]]
-    assert alphas[0] == pytest.approx(0.25)
+    assert alphas[0] == pytest.approx(0.475)
     assert alphas[1] == pytest.approx(1.0)
     assert calls["colorbar"] == "Dose (µSv/h)"
     assert calls["show"] is True


### PR DESCRIPTION
## Summary
- make low-dose points more visible in mesh dose map by limiting alpha range
- update mesh dose map test expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4b6e4dc8324b428a17e90feb923