### PR TITLE
Enhance dose map scaling for clarity

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -224,13 +224,13 @@ class MeshTallyView:
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")
         cmap = plt.cm.viridis
-        max_dose = df["dose"].max()
+        max_dose = df["dose"].quantile(0.95)
         if max_dose == 0:
             max_dose = 1
-        dose_norm = df["dose"] / max_dose
+        dose_norm = df["dose"].clip(upper=max_dose) / max_dose
         colors_arr = cmap(dose_norm)
-        # Keep points with low dose visible by scaling alpha between 0.3 and 1.0
-        colors_arr[:, 3] = 0.3 + 0.7 * dose_norm
+        # Fade out low-dose points so high doses stand out
+        colors_arr[:, 3] = 0.05 + 0.95 * (dose_norm**2)
         ax.scatter(
             df["x"],
             df["y"],

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -129,7 +129,7 @@ def test_plot_dose_map(monkeypatch):
     assert calls["projection"] == "3d"
     assert calls["scatter"] == ([1.0, 2.0], [2.0, 3.0], [3.0, 4.0])
     alphas = [col[3] for col in calls["colors"]]
-    assert alphas[0] == pytest.approx(0.475)
+    assert alphas[0] == pytest.approx(0.114, rel=1e-3)
     assert alphas[1] == pytest.approx(1.0)
     assert calls["colorbar"] == "Dose (µSv/h)"
     assert calls["show"] is True


### PR DESCRIPTION
## Summary
- scale dose map color limits using the 95th percentile and clip outliers
- fade low-dose points with squared alpha mapping so high doses stand out
- update tests for revised dose map transparency

## Testing
- `pytest tests/test_mesh_view.py::test_plot_dose_map -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a5fb5ddc832493c996af6ed06f88