### PR TITLE
Add 2D slice plotting for mesh tally dose

### DIFF
--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -23,6 +23,15 @@ def make_view():
     view.output_box = DummyText()
     view.msht_df = None
     view._get_total_rate = lambda: 1.0
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+        def get(self):
+            return self.value
+        def set(self, value):  # pragma: no cover - simple setter
+            self.value = value
+    view.axis_var = DummyVar("x")
+    view.slice_var = DummyVar("0")
     return view
 
 def test_load_msht_and_save_csv(tmp_path, monkeypatch):
@@ -131,5 +140,56 @@ def test_plot_dose_map(monkeypatch):
     alphas = [col[3] for col in calls["colors"]]
     assert alphas[0] == pytest.approx(0.114, rel=1e-3)
     assert alphas[1] == pytest.approx(1.0)
+    assert calls["colorbar"] == "Dose (µSv/h)"
+    assert calls["show"] is True
+
+
+def test_plot_dose_slice(monkeypatch):
+    view = make_view()
+
+    # Error when no data loaded
+    err = {}
+    monkeypatch.setattr(
+        mesh_view.Messagebox,
+        "show_error",
+        lambda title, msg: err.setdefault("t", title),
+        raising=False,
+    )
+    view.plot_dose_slice()
+    assert err.get("t") == "Dose Slice Error"
+
+    # Provide sample dataframe and set axis/value
+    view.msht_df = pd.DataFrame(
+        {"x": [1.0, 2.0], "y": [1.0, 1.0], "z": [0.0, 1.0], "dose": [1.0, 4.0]}
+    )
+    view.axis_var.set("y")
+    view.slice_var.set("1.0")
+
+    calls = {}
+
+    class DummyAx:
+        def scatter(self, x, y, c, marker, s):
+            calls["scatter"] = (list(x), list(y))
+            calls["colors"] = c
+            return object()
+
+        def set_xlabel(self, label):
+            calls["xlabel"] = label
+
+        def set_ylabel(self, label):
+            calls["ylabel"] = label
+
+    class DummyFig:
+        def colorbar(self, sc, ax=None, label=""):
+            calls["colorbar"] = label
+
+    monkeypatch.setattr(mesh_view.plt, "subplots", lambda: (DummyFig(), DummyAx()))
+    monkeypatch.setattr(mesh_view.plt, "show", lambda: calls.setdefault("show", True))
+
+    view.plot_dose_slice()
+    assert calls["scatter"] == ([1.0, 2.0], [0.0, 1.0])
+    assert len(calls["colors"]) == 2
+    assert calls["xlabel"] == "X"
+    assert calls["ylabel"] == "Z"
     assert calls["colorbar"] == "Dose (µSv/h)"
     assert calls["show"] is True


### PR DESCRIPTION
## Summary
- allow selecting an axis and value to plot a 2-D slice of mesh tally doses
- render dose slice with colorbar in GUI
- add tests for slice plotting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a833c20c8324a8a7b1f6683114a3