### PR TITLE
Use nearest mesh value for dose slices

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -291,7 +291,10 @@ class MeshTallyView:
             Messagebox.show_error("Dose Slice Error", "Invalid axis")
             return
 
-        mask = (df[axis] - slice_val).abs() < 1e-6
+        nearest_idx = (df[axis] - slice_val).abs().idxmin()
+        nearest_val = df.loc[nearest_idx, axis]
+        self.slice_var.set(f"{nearest_val:g}")
+        mask = (df[axis] - nearest_val).abs() < 1e-6
         slice_df = df[mask]
         if slice_df.empty:
             Messagebox.show_error("Dose Slice Error", "No data at specified slice")

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -193,3 +193,12 @@ def test_plot_dose_slice(monkeypatch):
     assert calls["ylabel"] == "Z"
     assert calls["colorbar"] == "Dose (µSv/h)"
     assert calls["show"] is True
+
+    calls.clear()
+    view.msht_df = pd.DataFrame(
+        {"x": [1.0, 2.0], "y": [0.0, 2.0], "z": [0.0, 1.0], "dose": [1.0, 4.0]}
+    )
+    view.slice_var.set("1.4")
+    view.plot_dose_slice()
+    assert calls["scatter"] == ([2.0], [1.0])
+    assert view.slice_var.get() == "2"


### PR DESCRIPTION
## Summary
- allow dose slice plotting to snap to the nearest mesh coordinate
- update slice value in the UI to reflect the chosen coordinate
- add tests for nearest coordinate selection when requested slice is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa214a4c8324a93ecaf4dcc09d7a