### PR TITLE
Display 2D dose maps without transparency

### DIFF
--- a/mesh_view.py
+++ b/mesh_view.py
@@ -310,7 +310,7 @@ class MeshTallyView:
             max_dose = 1
         dose_norm = slice_df["dose"].clip(upper=max_dose) / max_dose
         colors_arr = cmap(dose_norm)
-        colors_arr[:, 3] = 0.05 + 0.95 * (dose_norm**2)
+        # Display 2-D slices without transparency for a clearer dose map
         ax.scatter(
             slice_df[x_axis],
             slice_df[y_axis],

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -189,6 +189,8 @@ def test_plot_dose_slice(monkeypatch):
     view.plot_dose_slice()
     assert calls["scatter"] == ([1.0, 2.0], [0.0, 1.0])
     assert len(calls["colors"]) == 2
+    alphas = [col[3] for col in calls["colors"]]
+    assert all(alpha == pytest.approx(1.0) for alpha in alphas)
     assert calls["xlabel"] == "X"
     assert calls["ylabel"] == "Z"
     assert calls["colorbar"] == "Dose (µSv/h)"


### PR DESCRIPTION
## Summary
- remove alpha scaling from 2D dose slices so colors are fully opaque
- test that 2D dose slice colors are opaque

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ab94bea883248476d85510b72219