### PR TITLE
Ensure settings merge with existing config to retain selections

### DIFF
--- a/src/mcnp/views/settings_view.py
+++ b/src/mcnp/views/settings_view.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 import tkinter as tk
@@ -8,6 +7,8 @@ from typing import Any
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox
 import logging
+
+from ..utils import config_utils
 
 
 class SettingsView:
@@ -73,8 +74,7 @@ class SettingsView:
             self.app.base_dir = new_path
             self.mcnp_path_var.set(new_path)
             try:
-                with open(self.app.settings_path, "w") as f:
-                    json.dump({"MY_MCNP_PATH": new_path}, f)
+                config_utils.save_settings({"MY_MCNP_PATH": new_path})
                 os.environ["MY_MCNP"] = new_path
                 try:
                     from .. import run_packages
@@ -116,8 +116,7 @@ class SettingsView:
                 "plot_ext": self.app.plot_ext_var.get(),
                 "show_fig_heading": self.app.show_fig_heading_var.get(),
             }
-            with open(self.app.settings_path, "w") as f:
-                json.dump(settings, f)
+            config_utils.save_settings(settings)
             self.app.log("Settings saved.")
         except Exception as e:
             self.app.log(f"Failed to save settings: {e}", logging.ERROR)

--- a/tests/test_settings_view_config.py
+++ b/tests/test_settings_view_config.py
@@ -1,0 +1,74 @@
+import sys
+import json
+import logging
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+
+from mcnp.views import settings_view
+from mcnp.utils import config_utils
+
+
+class DummyVar:
+    def __init__(self, value=None):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):  # pragma: no cover - simple setter
+        self.value = value
+
+
+class DummyApp:
+    def __init__(self, settings_path: Path):
+        self.settings_path = str(settings_path)
+        self.base_dir = "/path"
+        self.mcnp_jobs_var = DummyVar(3)
+        self.dark_mode_var = DummyVar(False)
+        self.save_csv_var = DummyVar(True)
+        self.neutron_yield = DummyVar("single")
+        self.theme_var = DummyVar("flatly")
+        self.plot_ext_var = DummyVar("pdf")
+        self.show_fig_heading_var = DummyVar(True)
+        self.analysis_view = types.SimpleNamespace(save_config=lambda: None)
+        self.logs = []
+
+    def log(self, message, level=logging.INFO):  # pragma: no cover - simple logger
+        self.logs.append(message)
+
+
+def make_view(app):
+    view = settings_view.SettingsView.__new__(settings_view.SettingsView)
+    view.app = app
+    view.mcnp_path_var = DummyVar(app.base_dir)
+    view.default_jobs_var = DummyVar(app.mcnp_jobs_var.get())
+    view.theme_var = app.theme_var
+    view.toggle_theme = lambda: None
+    return view
+
+
+def test_save_settings_merges_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_utils, "PROJECT_SETTINGS_PATH", tmp_path / "config.json")
+    config_utils.save_settings({"sources": {"A": True}})
+    app = DummyApp(config_utils.PROJECT_SETTINGS_PATH)
+    view = make_view(app)
+    view.save_settings()
+    data = json.loads(config_utils.PROJECT_SETTINGS_PATH.read_text())
+    assert data["sources"] == {"A": True}
+    assert data["default_jobs"] == 3
+
+
+def test_change_mcnp_path_preserves_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_utils, "PROJECT_SETTINGS_PATH", tmp_path / "config.json")
+    config_utils.save_settings({"sources": {"A": True}})
+    app = DummyApp(config_utils.PROJECT_SETTINGS_PATH)
+    view = make_view(app)
+    monkeypatch.setattr(settings_view.filedialog, "askdirectory", lambda title="": "/new/path")
+    view.change_mcnp_path()
+    data = json.loads(config_utils.PROJECT_SETTINGS_PATH.read_text())
+    assert data["sources"] == {"A": True}
+    assert data["MY_MCNP_PATH"] == "/new/path"


### PR DESCRIPTION
## Summary
- use centralized save_settings helper when changing MCNP path or saving settings
- add regression tests to confirm config values like source selections persist

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c29ff5501483248c773e41c9307b59