### PR TITLE
Use jet colormap for dose maps

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -323,7 +323,7 @@ class MeshTallyView:
 
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")
-        cmap = plt.cm.viridis
+        cmap = plt.cm.jet
         quant_var = getattr(self, "dose_quantile_var", None)
         quant = (quant_var.get() / 100) if quant_var else 0.95
         max_dose = df["dose"].quantile(quant)
@@ -387,7 +387,7 @@ class MeshTallyView:
         x_axis, y_axis = axes[axis]
 
         fig, ax = plt.subplots()
-        cmap = plt.cm.viridis
+        cmap = plt.cm.jet
         quant_var = getattr(self, "dose_quantile_var", None)
         quant = (quant_var.get() / 100) if quant_var else 0.95
         max_dose = slice_df["dose"].quantile(quant)


### PR DESCRIPTION
## Summary
- switch dose map colormap from viridis to jet for blue-to-red scaling

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c2bbfdcdd8832484fc4e508166599e