### PR TITLE
Add volume utilities with vedo support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
   "pandas",
   "numpy",
   "matplotlib",
-  "ttkbootstrap"
+  "ttkbootstrap",
+  "vedo"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 numpy
 matplotlib
 ttkbootstrap
+vedo

--- a/src/mcnp/utils/__init__.py
+++ b/src/mcnp/utils/__init__.py
@@ -1,1 +1,5 @@
 """Utility helpers for MCNP Tools."""
+
+from .volume_utils import scatter_to_array, array_to_volume
+
+__all__ = ["scatter_to_array", "array_to_volume"]

--- a/src/mcnp/utils/volume_utils.py
+++ b/src/mcnp/utils/volume_utils.py
@@ -1,0 +1,75 @@
+"""Utilities for creating 3D volumes from scatter data."""
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+
+
+ArrayLike = Sequence[int] | np.ndarray
+
+
+def scatter_to_array(
+    x: ArrayLike,
+    y: ArrayLike,
+    z: ArrayLike,
+    values: ArrayLike,
+    shape: Tuple[int, int, int],
+    dtype: type[np.number] = np.float32,
+) -> np.ndarray:
+    """Convert scatter coordinates into a 3D numpy array.
+
+    Parameters
+    ----------
+    x, y, z:
+        Sequences of the same length representing the coordinates of the
+        scattered points.
+    values:
+        Values associated with each coordinate triple.
+    shape:
+        Shape of the resulting 3D array (nx, ny, nz).
+    dtype:
+        Desired dtype of the output array. Defaults to ``np.float32``.
+
+    Returns
+    -------
+    numpy.ndarray
+        A 3D array with ``values`` placed at the specified coordinates and
+        zeros elsewhere.
+    """
+
+    arr = np.zeros(shape, dtype=dtype)
+    arr[np.asarray(x), np.asarray(y), np.asarray(z)] = values
+    return arr
+
+
+def array_to_volume(array: np.ndarray):
+    """Create a ``vedo.Volume`` from a 3D numpy array.
+
+    The import of :mod:`vedo` happens inside the function so that projects that
+    merely rely on :func:`scatter_to_array` do not require the optional
+    ``vedo`` dependency.
+    """
+
+    from vedo import Volume
+
+    return Volume(array)
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    from vedo import show
+
+    data_matrix = scatter_to_array(
+        x=[0, 30, 50],
+        y=[0, 30, 60],
+        z=[0, 30, 70],
+        values=[1, 2, 3],
+        shape=(70, 80, 90),
+        dtype=np.uint8,
+    )
+
+    vol = array_to_volume(data_matrix)
+    vol.cmap(["white", "b", "g", "r"]).mode(1)
+    vol.add_scalarbar()
+
+    show(vol, __doc__, axes=1).close()

--- a/tests/test_volume_utils.py
+++ b/tests/test_volume_utils.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from mcnp.utils import scatter_to_array
+
+
+def test_scatter_to_array_basic():
+    x = [0, 1]
+    y = [0, 1]
+    z = [0, 1]
+    values = [5, 10]
+    arr = scatter_to_array(x, y, z, values, shape=(2, 2, 2))
+
+    expected = np.zeros((2, 2, 2), dtype=np.float32)
+    expected[0, 0, 0] = 5
+    expected[1, 1, 1] = 10
+
+    assert np.array_equal(arr, expected)


### PR DESCRIPTION
## Summary
- add `scatter_to_array` and `array_to_volume` helpers for turning scatter data into a vedo Volume
- expose new utilities via `mcnp.utils`
- include unit tests and optional vedo dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2cba8ec9883249231f3e60ba953f5