### PR TITLE
Allow selecting STL folder for dose map meshes

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -36,7 +36,7 @@ except Exception:  # pragma: no cover - vedo not available
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox
 
-from ..he3_plotter.io_utils import select_file
+from ..he3_plotter.io_utils import select_file, select_folder
 from ..utils import msht_parser
 from ..utils.mesh_bins_helper import plan_mesh_from_mesh
 
@@ -335,20 +335,32 @@ class MeshTallyView:
             raise ValueError("No MSHT data loaded")
         return self.msht_df
 
-    def load_stl_files(self):
+    def load_stl_files(self, folderpath: str | None = None) -> list[Any]:
+        """Load all STL files from a folder and return ``vedo`` meshes."""
 
-        folderpath = "/Users/ioanhughes/Downloads/Uol_n_lab/Materials"
+        if vedo is None:  # pragma: no cover - optional dependency
+            return []
 
-        files_in_folder = os.listdir(folderpath)
-        stl_files = [f for f in files_in_folder if f.endswith('.stl')]
-        print(stl_files)
-        meshes = []
+        if folderpath is None:
+            folderpath = select_folder("Select folder with STL files")
+            if not folderpath:
+                return []
+
+        try:
+            files_in_folder = os.listdir(folderpath)
+        except OSError:
+            logging.getLogger(__name__).error(
+                "Failed to list files in folder %s", folderpath
+            )
+            return []
+
+        stl_files = [f for f in files_in_folder if f.lower().endswith(".stl")]
+        meshes: list[Any] = []
         for file in stl_files:
             full_path = os.path.join(folderpath, file)
-            print(full_path)
-            # Here you can add code to process each STL file as needed
-            vedo_mesh = vedo.Mesh(full_path).alpha(0.5).c('lightblue').wireframe(False)
-
+            vedo_mesh = (
+                vedo.Mesh(full_path).alpha(0.5).c("lightblue").wireframe(False)
+            )
             meshes.append(vedo_mesh)
 
         return meshes

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -233,3 +233,28 @@ def test_plot_dose_slice(monkeypatch):
     view.plot_dose_slice()
     assert calls["scatter"] == ([2.0], [1.0])
     assert view.slice_var.get() == "2"
+
+
+def test_load_stl_files(tmp_path, monkeypatch):
+    view = make_view()
+
+    stl_file = tmp_path / "sample.stl"
+    stl_file.write_text("", encoding="utf-8")
+    (tmp_path / "ignore.txt").write_text("", encoding="utf-8")
+
+    class DummyMesh:
+        def __init__(self, path):
+            self.path = path
+        def alpha(self, *a, **k):
+            return self
+        def c(self, *a, **k):
+            return self
+        def wireframe(self, *a, **k):
+            return self
+
+    dummy_vedo = type("Vedo", (), {"Mesh": DummyMesh})
+    monkeypatch.setattr(mesh_view, "vedo", dummy_vedo)
+
+    meshes = view.load_stl_files(folderpath=str(tmp_path))
+    assert len(meshes) == 1
+    assert meshes[0].path == str(stl_file)


### PR DESCRIPTION
## Summary
- allow users to choose a folder of STL meshes instead of relying on a hardcoded path
- add regression test for loading meshes from a directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e4c3025483248e75046f2a17ef67