### PR TITLE
Use explicit axis labels for 3D plots

### DIFF
--- a/src/mcnp/utils/volume_utils.py
+++ b/src/mcnp/utils/volume_utils.py
@@ -9,6 +9,9 @@ import numpy as np
 ArrayLike = Sequence[int] | np.ndarray
 
 
+AXES_LABELS = {"xTitle": "x (cm)", "yTitle": "y (cm)", "zTitle": "z (cm)"}
+
+
 def scatter_to_array(
     x: ArrayLike,
     y: ArrayLike,
@@ -72,4 +75,4 @@ if __name__ == "__main__":  # pragma: no cover - example usage
     vol.cmap(["white", "b", "g", "r"]).mode(1)
     vol.add_scalarbar()
 
-    show(vol, __doc__, axes=1).close()
+    show(vol, __doc__, axes=AXES_LABELS).close()

--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -44,6 +44,9 @@ from ..utils.mesh_bins_helper import plan_mesh_from_mesh
 CONFIG_FILE = Path(__file__).resolve().parents[3] / "config.json"
 
 
+AXES_LABELS = {"xTitle": "x (cm)", "yTitle": "y (cm)", "zTitle": "z (cm)"}
+
+
 class MeshTallyView:
     """UI for mesh tally related tools."""
 
@@ -449,14 +452,14 @@ class MeshTallyView:
             if Slicer3DPlotter is None:  # pragma: no cover - optional dependency
                 Messagebox.show_error("Dose Map Error", "Slice viewer not available")
                 return
-            plt = Slicer3DPlotter(vol, axes=1)
+            plt = Slicer3DPlotter(vol, axes=AXES_LABELS)
             for mesh in meshes:
                 mesh.probe(vol)
                 mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
                 plt += mesh
             plt.show()
         else:
-            show(vol, meshes, axes=1)
+            show(vol, meshes, axes=AXES_LABELS)
 
 
     # ------------------------------------------------------------------

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -151,7 +151,7 @@ def test_plot_dose_map(monkeypatch):
     assert linear_calls["grid"][1][0][0] == pytest.approx(linear_calls["cmap"][2])
     assert linear_calls["cmap"][0] == "viridis"
     assert linear_calls["scalarbar"] == "Dose (µSv/h)"
-    assert linear_calls["show"] == 1
+    assert linear_calls["show"] == mesh_view.AXES_LABELS
 
     # Log scaling assertions
     max_dose = view.msht_df["dose"].quantile(0.95)
@@ -159,6 +159,7 @@ def test_plot_dose_map(monkeypatch):
     assert log_calls["grid"][1][0][0] == pytest.approx(np.log10(max_dose))
     assert log_calls["cmap"][1] == pytest.approx(np.log10(1.0))
     assert log_calls["cmap"][2] == pytest.approx(np.log10(max_dose))
+    assert log_calls["show"] == mesh_view.AXES_LABELS
 
 
 def test_plot_dose_map_slice_viewer(monkeypatch):
@@ -184,7 +185,7 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
             return self
 
     class DummyPlotter:
-        def __init__(self, volume, axes=1):
+        def __init__(self, volume, axes=None):
             calls["axes"] = axes
         def __iadd__(self, obj):  # pragma: no cover - simple add
             return self
@@ -199,7 +200,7 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
     monkeypatch.setattr(mesh_view, "show", lambda *a, **k: calls.setdefault("plain_show", True))
 
     view.plot_dose_map()
-    assert calls["axes"] == 1
+    assert calls["axes"] == mesh_view.AXES_LABELS
     assert calls["show"] is True
     assert calls["vol_cmap"][0] == "magma"
     assert calls["mesh_cmap"][0] == "magma"


### PR DESCRIPTION
## Summary
- replace numeric `axes` parameter with explicit axis-title dictionary
- ensure `Slicer3DPlotter` and `show` receive matching axis labels
- add regression checks confirming axis label dictionary is passed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c417ccc104832488e88f7328ad1609