### PR TITLE
Fix screenshot save for dose map

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -21,11 +21,10 @@ import matplotlib.pyplot as plt
 from matplotlib import colors
 
 try:  # Optional dependency for 3-D dose maps
-    from vedo import Volume, show, screenshot
+    from vedo import Volume, show
 except Exception:  # pragma: no cover - vedo not available
     Volume = None  # type: ignore[assignment]
     show = None  # type: ignore[assignment]
-    screenshot = None  # type: ignore[assignment]
 
 try:  # Optional imports for slice viewer
     import vedo  # pragma: no cover - optional dependency
@@ -491,7 +490,7 @@ class MeshTallyView:
     def save_dose_map(self) -> None:
         """Save a screenshot of the 3-D dose map using ``vedo``."""
 
-        if Volume is None or show is None or screenshot is None:  # pragma: no cover - vedo missing
+        if Volume is None or show is None:  # pragma: no cover - vedo missing
             Messagebox.show_error("Dose Map Error", "Vedo library not available")
             return
 
@@ -518,7 +517,7 @@ class MeshTallyView:
                 mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
                 plt += mesh
             plt.show(interactive=False)
-            screenshot(filepath, plotter=plt)
+            plt.screenshot(filepath)
             plt.close()
         else:
             plt = show(
@@ -529,7 +528,7 @@ class MeshTallyView:
                 interactive=False,
                 offscreen=True,
             )
-            screenshot(filepath, plotter=plt)
+            plt.screenshot(filepath)
             plt.close()
 
 

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -373,6 +373,8 @@ def test_save_dose_map(monkeypatch, tmp_path):
             return self
 
     class DummyPlotter:
+        def screenshot(self, path):
+            calls["screenshot"] = path
         def close(self):
             calls["closed"] = True
 
@@ -380,12 +382,8 @@ def test_save_dose_map(monkeypatch, tmp_path):
         calls["show"] = True
         return DummyPlotter()
 
-    def dummy_screenshot(path, plotter=None):
-        calls["screenshot"] = path
-
     monkeypatch.setattr(mesh_view, "Volume", DummyVolume)
     monkeypatch.setattr(mesh_view, "show", dummy_show)
-    monkeypatch.setattr(mesh_view, "screenshot", dummy_screenshot)
     monkeypatch.setattr(
         mesh_view,
         "asksaveasfilename",
@@ -423,6 +421,8 @@ def test_save_dose_map_slice_viewer(monkeypatch, tmp_path):
             return self
         def show(self, interactive=False):
             pass
+        def screenshot(self, path):
+            calls.setdefault("screenshot", path)
         def close(self):
             pass
 
@@ -430,7 +430,6 @@ def test_save_dose_map_slice_viewer(monkeypatch, tmp_path):
 
     monkeypatch.setattr(mesh_view, "Volume", DummyVolume)
     monkeypatch.setattr(mesh_view, "Slicer3DPlotter", DummyPlotter)
-    monkeypatch.setattr(mesh_view, "screenshot", lambda path, plotter=None: calls.setdefault("screenshot", path))
     monkeypatch.setattr(mesh_view, "asksaveasfilename", lambda **k: str(tmp_path / "slice.png"))
     view.load_stl_files = lambda: [DummyMesh()]
 


### PR DESCRIPTION
## Summary
- use vedo Plotter's `screenshot` method to save dose map images
- adjust tests for new screenshot handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c41fd910ec83249428aa749f68d90d