### PR TITLE
feat(mesh): persist file paths and slice selection

### DIFF
--- a/tests/test_mesh_config.py
+++ b/tests/test_mesh_config.py
@@ -31,6 +31,13 @@ def create_mesh_view(app, mesh_view_module):
     }
     mv.custom_var = DummyVar(False)
     mv.custom_value_var = DummyVar("")
+    mv.axis_var = DummyVar("y")
+    mv.slice_var = DummyVar("0")
+    mv.slice_viewer_var = DummyVar(False)
+    mv.msht_path = None
+    mv.stl_folder = None
+    mv.msht_path_var = DummyVar("MSHT file: None")
+    mv.stl_folder_var = DummyVar("STL folder: None")
     return mv
 
 
@@ -49,15 +56,30 @@ def test_mesh_view_config(tmp_path, monkeypatch):
     mv.source_vars["Big tank (2.5e6)"].set(True)
     mv.custom_var.set(True)
     mv.custom_value_var.set("3e6")
+    mv.axis_var.set("x")
+    mv.slice_var.set("1")
+    mv.slice_viewer_var.set(True)
+    mv.msht_path = "last.msht"
+    mv.stl_folder = "stl_folder"
     mv.save_config()
 
     data = json.loads((tmp_path / "config.json").read_text())
     assert data["sources"]["Big tank (2.5e6)"] is True
     assert data["custom_source"] == {"enabled": True, "value": "3e6"}
     assert data["other"] == 1
+    assert data["msht_path"] == "last.msht"
+    assert data["stl_folder"] == "stl_folder"
+    assert data["slice_viewer"] is True
+    assert data["slice_axis"] == "x"
+    assert data["slice_value"] == "1"
 
     mv2 = create_mesh_view(app, mesh_view_module)
     mv2.load_config()
     assert mv2.source_vars["Big tank (2.5e6)"].get() is True
     assert mv2.custom_var.get() is True
     assert mv2.custom_value_var.get() == "3e6"
+    assert mv2.msht_path == "last.msht"
+    assert mv2.stl_folder == "stl_folder"
+    assert mv2.axis_var.get() == "x"
+    assert mv2.slice_var.get() == "1"
+    assert mv2.slice_viewer_var.get() is True

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -38,6 +38,10 @@ def make_view():
     view.slice_viewer_var = DummyVar(False)
     view.cmap_var = DummyVar("jet")
     view.log_scale_var = DummyVar(False)
+    view.msht_path_var = DummyVar("MSHT file: None")
+    view.stl_folder_var = DummyVar("STL folder: None")
+    view.msht_path = None
+    view.stl_folder = None
     return view
 
 def test_load_msht_and_save_csv(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- show selected MSHT file and STL folder paths in Mesh Tally view
- remember last-used MSHT/STL paths and slice viewer settings in config
- update tests for new configuration fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c42789e4bc8324af6138abfa2a1249