### PR TITLE
Refactor: isolate vedo 3D plotting utilities

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -1,0 +1,126 @@
+"""Utilities for 3-D plotting with ``vedo``."""
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import vedo  # type: ignore
+    from vedo import Volume, show  # type: ignore
+    from vedo.applications import Slicer3DPlotter  # type: ignore
+except Exception:  # pragma: no cover - vedo not available
+    vedo = None  # type: ignore[assignment]
+    Volume = None  # type: ignore[assignment]
+    show = None  # type: ignore[assignment]
+    Slicer3DPlotter = None  # type: ignore[assignment]
+
+AXES_LABELS = {"xTitle": "x (cm)", "yTitle": "y (cm)", "zTitle": "z (cm)"}
+
+
+def load_stl_meshes(folderpath: str) -> tuple[list[Any], list[str]]:
+    """Load all STL files from *folderpath* as ``vedo`` meshes."""
+    if vedo is None:  # pragma: no cover - optional dependency
+        return [], []
+    files_in_folder = os.listdir(folderpath)
+    stl_files = [f for f in files_in_folder if f.lower().endswith(".stl")]
+    meshes: list[Any] = []
+    for file in stl_files:
+        full_path = os.path.join(folderpath, file)
+        mesh = vedo.Mesh(full_path).alpha(0.5).c("lightblue").wireframe(False)
+        meshes.append(mesh)
+    return meshes, stl_files
+
+
+def build_volume(
+    df: pd.DataFrame,
+    stl_meshes: list[Any] | None,
+    *,
+    cmap_name: str,
+    dose_quantile: float,
+    log_scale: bool,
+    warning_cb: Callable[[str, str], None] | None = None,
+) -> tuple[Any, list[Any], str, float, float]:
+    """Construct the ``vedo`` volume and meshes for dose mapping."""
+    if stl_meshes is None:
+        raise ValueError("No STL files loaded")
+
+    quant = dose_quantile / 100
+    max_dose = df["dose"].quantile(quant)
+    if max_dose == 0:
+        max_dose = 1
+    min_dose = df[df["dose"] > 0]["dose"].min()
+    if not pd.notna(min_dose) or min_dose <= 0:
+        min_dose = max_dose / 1e6
+
+    xs = np.sort(df["x"].unique())
+    ys = np.sort(df["y"].unique())
+    zs = np.sort(df["z"].unique())
+    nx, ny, nz = len(xs), len(ys), len(zs)
+
+    def _check_uniform(arr: np.ndarray, label: str) -> None:
+        if len(arr) > 1:
+            diffs = np.diff(arr)
+            if not np.allclose(diffs, diffs[0]) and warning_cb is not None:
+                warning_cb(
+                    "Non-uniform mesh spacing",
+                    f"{label}-coordinates are not uniformly spaced; using first spacing value.",
+                )
+
+    _check_uniform(xs, "X")
+    _check_uniform(ys, "Y")
+    _check_uniform(zs, "Z")
+
+    grid = (
+        df.pivot_table(index="z", columns=["y", "x"], values="dose")
+        .fillna(0.0)
+        .to_numpy()
+        .reshape(nz, ny, nx)
+        .transpose(2, 1, 0)
+    )
+    grid = np.clip(grid, min_dose, max_dose)
+
+    if log_scale:
+        grid = np.log10(grid)
+        min_dose = np.log10(min_dose)
+        max_dose = np.log10(max_dose)
+        bar_title = "Log10 Dose (µSv/h)"
+    else:
+        bar_title = "Dose (µSv/h)"
+
+    dx = xs[1] - xs[0] if nx > 1 else 1.0
+    dy = ys[1] - ys[0] if ny > 1 else 1.0
+    dz = zs[1] - zs[0] if nz > 1 else 1.0
+
+    vol = Volume(grid, spacing=(dx, dy, dz), origin=(xs[0], ys[0], zs[0]))
+    vol.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
+    vol.add_scalarbar(title=bar_title)
+    return vol, stl_meshes, cmap_name, min_dose, max_dose
+
+
+def show_dose_map(
+    vol: Any,
+    meshes: list[Any],
+    cmap_name: str,
+    min_dose: float,
+    max_dose: float,
+    *,
+    slice_viewer: bool,
+    axes: dict[str, str] = AXES_LABELS,
+) -> None:
+    """Render a 3-D dose map using ``vedo``."""
+    if slice_viewer:
+        if Slicer3DPlotter is None:
+            raise RuntimeError("Slice viewer not available")
+        plt = Slicer3DPlotter(vol, axes=axes)
+        for mesh in meshes:
+            mesh.probe(vol)
+            mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
+            plt += mesh
+        plt.show()
+    else:
+        plt = show(vol, meshes, axes=axes, interactive=False)
+        if hasattr(plt, "interactive"):
+            plt.interactive()

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
-from mcnp.views import mesh_view
+from mcnp.views import mesh_view, vedo_plotter
 
 class DummyText:
     def __init__(self):
@@ -145,9 +145,9 @@ def test_plot_dose_map(monkeypatch):
             calls["scalarbar"] = title
             return self
 
-    monkeypatch.setattr(mesh_view, "Volume", DummyVolume)
+    monkeypatch.setattr(vedo_plotter, "Volume", DummyVolume)
     monkeypatch.setattr(
-        mesh_view, "show", lambda *a, **kw: calls.setdefault("show", kw.get("axes"))
+        vedo_plotter, "show", lambda *a, **kw: calls.setdefault("show", kw.get("axes"))
     )
 
     # Linear scaling
@@ -203,8 +203,8 @@ def test_plot_dose_map_nonuniform_spacing(monkeypatch):
         def add_scalarbar(self, *a, **k):
             return self
 
-    monkeypatch.setattr(mesh_view, "Volume", DummyVolume)
-    monkeypatch.setattr(mesh_view, "show", lambda *a, **k: None)
+    monkeypatch.setattr(vedo_plotter, "Volume", DummyVolume)
+    monkeypatch.setattr(vedo_plotter, "show", lambda *a, **k: None)
 
     view.plot_dose_map()
     assert "Non-uniform mesh spacing" in warnings
@@ -244,9 +244,11 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
     view.stl_meshes = [DummyMesh()]
     view.slice_viewer_var.set(True)
 
-    monkeypatch.setattr(mesh_view, "Volume", DummyVolume)
-    monkeypatch.setattr(mesh_view, "Slicer3DPlotter", DummyPlotter)
-    monkeypatch.setattr(mesh_view, "show", lambda *a, **k: calls.setdefault("plain_show", True))
+    monkeypatch.setattr(vedo_plotter, "Volume", DummyVolume)
+    monkeypatch.setattr(vedo_plotter, "Slicer3DPlotter", DummyPlotter)
+    monkeypatch.setattr(
+        vedo_plotter, "show", lambda *a, **k: calls.setdefault("plain_show", True)
+    )
 
     view.plot_dose_map()
     assert calls["axes"] == mesh_view.AXES_LABELS
@@ -365,7 +367,7 @@ def test_load_stl_files(tmp_path, monkeypatch):
             return self
 
     dummy_vedo = type("Vedo", (), {"Mesh": DummyMesh})
-    monkeypatch.setattr(mesh_view, "vedo", dummy_vedo)
+    monkeypatch.setattr(vedo_plotter, "vedo", dummy_vedo)
 
     meshes = view.load_stl_files(folderpath=str(tmp_path))
     assert len(meshes) == 1


### PR DESCRIPTION
## Summary
- Move all vedo-based 3D plotting logic into new `vedo_plotter` module
- Update mesh view to use `vedo_plotter` for loading STL meshes and rendering dose maps
- Adjust tests to reflect new plotting module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c42a729c6c8324b9df7fb497c7833e