### PR TITLE
Default jet colormap and larger scalar bar

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -38,7 +38,7 @@ def build_volume(
     df: pd.DataFrame,
     stl_meshes: list[Any] | None,
     *,
-    cmap_name: str,
+    cmap_name: str = "jet",
     dose_quantile: float,
     log_scale: bool,
     warning_cb: Callable[[str, str], None] | None = None,
@@ -96,7 +96,7 @@ def build_volume(
 
     vol = Volume(grid, spacing=(dx, dy, dz), origin=(xs[0], ys[0], zs[0]))
     vol.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
-    vol.add_scalarbar(title=bar_title)
+    vol.add_scalarbar(title=bar_title, size=(100, 600), font_size=24)
     return vol, stl_meshes, cmap_name, min_dose, max_dose
 
 

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -141,8 +141,12 @@ def test_plot_dose_map(monkeypatch):
             calls["cmap"] = (cmap_name, vmin, vmax)
             return self
 
-        def add_scalarbar(self, title=""):
-            calls["scalarbar"] = title
+        def add_scalarbar(self, title="", size=None, font_size=None):
+            calls["scalarbar"] = {
+                "title": title,
+                "size": size,
+                "font_size": font_size,
+            }
             return self
 
     monkeypatch.setattr(vedo_plotter, "Volume", DummyVolume)
@@ -166,7 +170,9 @@ def test_plot_dose_map(monkeypatch):
     # Second value is clipped to the chosen max dose
     assert linear_calls["grid"][1][0][0] == pytest.approx(linear_calls["cmap"][2])
     assert linear_calls["cmap"][0] == "viridis"
-    assert linear_calls["scalarbar"] == "Dose (µSv/h)"
+    assert linear_calls["scalarbar"]["title"] == "Dose (µSv/h)"
+    assert linear_calls["scalarbar"]["size"] == (100, 600)
+    assert linear_calls["scalarbar"]["font_size"] == 24
     assert linear_calls["show"] == mesh_view.AXES_LABELS
 
     # Log scaling assertions
@@ -223,7 +229,7 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
         def cmap(self, cmap_name, vmin=None, vmax=None):
             calls["vol_cmap"] = (cmap_name, vmin, vmax)
             return self
-        def add_scalarbar(self, title=""):
+        def add_scalarbar(self, title="", size=None, font_size=None):  # pragma: no cover - simple stub
             return self
 
     class DummyMesh:


### PR DESCRIPTION
## Summary
- Default `build_volume` color map to `jet`
- Enlarge the scalar bar for dose plots for better visibility
- Update tests to cover new scalar bar parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c42d982194832484ecbf08567e0713