### PR TITLE
Add VTK button to toggle slice viewer

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -111,7 +111,19 @@ def show_dose_map(
     axes: dict[str, str] = AXES_LABELS,
 ) -> None:
     """Render a 3-D dose map using ``vedo``."""
-    if slice_viewer:
+    def _render_plain() -> None:
+        plt = show(vol, meshes, axes=axes, interactive=False)
+
+        def _to_slicer() -> None:
+            plt.close()
+            _render_slicer()
+
+        if hasattr(plt, "add_button"):
+            plt.add_button(_to_slicer, states=("Slice Viewer",), bc=("gray25",))
+        if hasattr(plt, "interactive"):
+            plt.interactive()
+
+    def _render_slicer() -> None:
         if Slicer3DPlotter is None:
             raise RuntimeError("Slice viewer not available")
         plt = Slicer3DPlotter(vol, axes=axes)
@@ -119,8 +131,16 @@ def show_dose_map(
             mesh.probe(vol)
             mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
             plt += mesh
+
+        def _to_plain() -> None:
+            plt.close()
+            _render_plain()
+
+        if hasattr(plt, "add_button"):
+            plt.add_button(_to_plain, states=("Volume View",), bc=("gray25",))
         plt.show()
+
+    if slice_viewer:
+        _render_slicer()
     else:
-        plt = show(vol, meshes, axes=axes, interactive=False)
-        if hasattr(plt, "interactive"):
-            plt.interactive()
+        _render_plain()


### PR DESCRIPTION
## Summary
- add VTK window button to switch between plain and slice viewer modes
- update tests for new in-window toggle capability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c435b1c5f483248e2a340e50e8cf32