### PR TITLE
Close Vedo plotter after dose map to avoid freezing

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -120,7 +120,11 @@ def show_dose_map(
             mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
             plt += mesh
         plt.show()
+        if hasattr(plt, "close"):
+            plt.close()
     else:
         plt = show(vol, meshes, axes=axes, interactive=False)
         if hasattr(plt, "interactive"):
             plt.interactive()
+        if hasattr(plt, "close"):
+            plt.close()

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -158,7 +158,7 @@ def test_plot_dose_map(monkeypatch):
         def interactive(self):
             calls["interactive"] = True
 
-        def close(self):  # pragma: no cover - not used here
+        def close(self):
             calls["closed"] = True
 
     def fake_show(*a, **kw):
@@ -186,6 +186,7 @@ def test_plot_dose_map(monkeypatch):
     assert linear_calls["scalarbar"]["size"] == (200, 600)
     assert linear_calls["scalarbar"]["font_size"] == 24
     assert linear_calls["show_axes"] == mesh_view.AXES_LABELS
+    assert linear_calls["closed"] is True
 
     # Log scaling assertions
     max_dose = view.msht_df["dose"].quantile(0.95)
@@ -194,6 +195,7 @@ def test_plot_dose_map(monkeypatch):
     assert log_calls["cmap"][1] == pytest.approx(np.log10(1.0))
     assert log_calls["cmap"][2] == pytest.approx(np.log10(max_dose))
     assert log_calls["show_axes"] == mesh_view.AXES_LABELS
+    assert log_calls["closed"] is True
 
 
 def test_plot_dose_map_nonuniform_spacing(monkeypatch):
@@ -274,8 +276,8 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
         def show(self):
             calls["show"] = True
 
-        def close(self):  # pragma: no cover - not used
-            pass
+        def close(self):
+            calls["closed"] = True
 
     view.stl_meshes = [DummyMesh()]
     view.slice_viewer_var.set(True)
@@ -305,6 +307,7 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
     assert calls["vol_cmap"][0] == "magma"
     assert calls["mesh_cmap"][0] == "magma"
     assert "plain_show" not in calls
+    assert calls["closed"] is True
 
 
 def test_plot_dose_slice(monkeypatch):


### PR DESCRIPTION
## Summary
- Ensure Vedo dose map plotter windows are closed after display
- Verify plotter closure in tests for dose map and slice viewer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43d01da9c8324b799f5bec978549b