### PR TITLE
Prevent Vedo window close from exiting app

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -119,11 +119,15 @@ def show_dose_map(
             mesh.probe(vol)
             mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
             plt += mesh
+        if hasattr(plt, "interactor") and plt.interactor:
+            plt.interactor.SetExitOnClose(False)
         plt.show()
         if hasattr(plt, "close"):
             plt.close()
     else:
         plt = show(vol, meshes, axes=axes, interactive=False)
+        if hasattr(plt, "interactor") and plt.interactor:
+            plt.interactor.SetExitOnClose(False)
         if hasattr(plt, "interactive"):
             plt.interactive()
         if hasattr(plt, "close"):


### PR DESCRIPTION
## Summary
- Ensure Vedo plotters disable `ExitOnClose` so closing their window doesn't terminate the application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4684c7ee483248a5aa4fa4c8b03d3