### PR TITLE
Handle missing SetExitOnClose in vedo plotter

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -119,14 +119,22 @@ def show_dose_map(
             mesh.probe(vol)
             mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
             plt += mesh
-        if hasattr(plt, "interactor") and plt.interactor:
+        if (
+            hasattr(plt, "interactor")
+            and plt.interactor
+            and hasattr(plt.interactor, "SetExitOnClose")
+        ):
             plt.interactor.SetExitOnClose(False)
         plt.show()
         if hasattr(plt, "close"):
             plt.close()
     else:
         plt = show(vol, meshes, axes=axes, interactive=False)
-        if hasattr(plt, "interactor") and plt.interactor:
+        if (
+            hasattr(plt, "interactor")
+            and plt.interactor
+            and hasattr(plt.interactor, "SetExitOnClose")
+        ):
             plt.interactor.SetExitOnClose(False)
         if hasattr(plt, "interactive"):
             plt.interactive()

--- a/tests/test_vedo_plotter.py
+++ b/tests/test_vedo_plotter.py
@@ -1,0 +1,25 @@
+from mcnp.views import vedo_plotter
+
+
+def test_show_dose_map_handles_missing_setexit(monkeypatch):
+    class DummyPlot:
+        def __init__(self):
+            self.interactor = object()
+        def interactive(self):
+            pass
+        def close(self):
+            pass
+    monkeypatch.setattr(vedo_plotter, "show", lambda *a, **k: DummyPlot())
+    vedo_plotter.show_dose_map(object(), [], "jet", 0.0, 1.0, slice_viewer=False)
+
+
+def test_show_dose_map_slice_viewer_missing_setexit(monkeypatch):
+    class DummyPlot:
+        def __init__(self):
+            self.interactor = object()
+        def show(self):
+            pass
+        def close(self):
+            pass
+    monkeypatch.setattr(vedo_plotter, "Slicer3DPlotter", lambda *a, **k: DummyPlot())
+    vedo_plotter.show_dose_map(object(), [], "jet", 0.0, 1.0, slice_viewer=True)


### PR DESCRIPTION
## Summary
- avoid AttributeError when VTK interactor lacks SetExitOnClose
- add tests ensuring dose map rendering works without SetExitOnClose

## Testing
- `PYTHONPATH=src pytest tests/test_vedo_plotter.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c472f1a110832494c2615decfa5f9a