### PR TITLE
Include origin coordinates in bin helper

### DIFF
--- a/src/mcnp/utils/mesh_bins_helper.py
+++ b/src/mcnp/utils/mesh_bins_helper.py
@@ -262,6 +262,9 @@ def plan_mesh_from_mesh(
     jmesh: float,
     kmesh: float,
     delta: float,
+    xorigin: float = 0.0,
+    yorigin: float = 0.0,
+    zorigin: float = 0.0,
     mode: str = "uniform",
     max_denominator: int = 1000,
     max_voxels: Optional[int] = None,
@@ -269,19 +272,28 @@ def plan_mesh_from_mesh(
     particle: str = "n",
     quantity: str = "flux",
 ) -> Dict:
-    """Convenience wrapper accepting IMESH/JMESH/KMESH end points.
-    The mesh is assumed to start at the origin (0, 0, 0), and the provided
-    values define the upper bounds along each axis. The returned dictionary
+    """Convenience wrapper accepting origin and IMESH/JMESH/KMESH coordinates.
+
+    MCNP defines mesh dimensions from one coordinate to another.  ``imesh``,
+    ``jmesh`` and ``kmesh`` are the endpoint coordinates along each axis, while
+    ``xorigin``, ``yorigin`` and ``zorigin`` are the corresponding origin
+    coordinates.  The total extent for each axis is the sum of the absolute
+    values of the origin and mesh coordinates.  The returned dictionary
     includes suggested ``iints``, ``jints`` and ``kints`` values for uniform
-    spacing."""
+    spacing.
+    """
+
+    xmax = abs(xorigin) + abs(imesh)
+    ymax = abs(yorigin) + abs(jmesh)
+    zmax = abs(zorigin) + abs(kmesh)
 
     return plan_mesh(
         xmin=0.0,
-        xmax=imesh,
+        xmax=xmax,
         ymin=0.0,
-        ymax=jmesh,
+        ymax=ymax,
         zmin=0.0,
-        zmax=kmesh,
+        zmax=zmax,
         delta=delta,
         mode=mode,
         max_denominator=max_denominator,
@@ -343,6 +355,9 @@ def main() -> None:
     p.add_argument("--imesh", type=float, help="Upper X bound (from IMESH)")
     p.add_argument("--jmesh", type=float, help="Upper Y bound (from JMESH)")
     p.add_argument("--kmesh", type=float, help="Upper Z bound (from KMESH)")
+    p.add_argument("--xorig", type=float, default=0.0, help="Origin X coordinate")
+    p.add_argument("--yorig", type=float, default=0.0, help="Origin Y coordinate")
+    p.add_argument("--zorig", type=float, default=0.0, help="Origin Z coordinate")
     p.add_argument("--iints", type=int, help="Number of x intervals (I mesh counts)")
     p.add_argument("--jints", type=int, help="Number of y intervals (J mesh counts)")
     p.add_argument("--kints", type=int, help="Number of z intervals (K mesh counts)")
@@ -363,6 +378,9 @@ def main() -> None:
             jmesh=args.jmesh,
             kmesh=args.kmesh,
             delta=args.delta,
+            xorigin=args.xorig,
+            yorigin=args.yorig,
+            zorigin=args.zorig,
             mode=args.mode,
             max_denominator=args.max_denominator,
             max_voxels=args.max_voxels,

--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -41,7 +41,10 @@ class MeshTallyView:
         self.app = app
         self.frame = parent
 
-        # Variables for bin helper inputs (mesh extents)
+        # Variables for bin helper inputs (origin and mesh extents)
+        self.xorigin_var = tk.StringVar()
+        self.yorigin_var = tk.StringVar()
+        self.zorigin_var = tk.StringVar()
         self.imesh_var = tk.StringVar()
         self.jmesh_var = tk.StringVar()
         self.kmesh_var = tk.StringVar()
@@ -97,13 +100,13 @@ class MeshTallyView:
         helper_frame = ttk.LabelFrame(self.frame, text="Bin Helper")
         helper_frame.pack(fill="x", padx=10, pady=10)
 
-        # First row: IMESH/JMESH/KMESH
-        entries = [
-            ("IMESH", self.imesh_var),
-            ("JMESH", self.jmesh_var),
-            ("KMESH", self.kmesh_var),
+        # First row: origin coordinates
+        origin_entries = [
+            ("X0", self.xorigin_var),
+            ("Y0", self.yorigin_var),
+            ("Z0", self.zorigin_var),
         ]
-        for i, (label, var) in enumerate(entries):
+        for i, (label, var) in enumerate(origin_entries):
             col = i * 2
             ttk.Label(helper_frame, text=label + ":").grid(
                 row=0, column=col, sticky="e", padx=5, pady=2
@@ -112,15 +115,30 @@ class MeshTallyView:
                 row=0, column=col + 1, padx=5, pady=2
             )
 
-        # Second row: delta and mode
+        # Second row: IMESH/JMESH/KMESH
+        mesh_entries = [
+            ("IMESH", self.imesh_var),
+            ("JMESH", self.jmesh_var),
+            ("KMESH", self.kmesh_var),
+        ]
+        for i, (label, var) in enumerate(mesh_entries):
+            col = i * 2
+            ttk.Label(helper_frame, text=label + ":").grid(
+                row=1, column=col, sticky="e", padx=5, pady=2
+            )
+            ttk.Entry(helper_frame, textvariable=var, width=10).grid(
+                row=1, column=col + 1, padx=5, pady=2
+            )
+
+        # Third row: delta and mode
         ttk.Label(helper_frame, text="delta:").grid(
-            row=1, column=0, sticky="e", padx=5, pady=2
+            row=2, column=0, sticky="e", padx=5, pady=2
         )
         ttk.Entry(helper_frame, textvariable=self.delta_var, width=10).grid(
-            row=1, column=1, padx=5, pady=2
+            row=2, column=1, padx=5, pady=2
         )
         ttk.Label(helper_frame, text="mode:").grid(
-            row=1, column=2, sticky="e", padx=5, pady=2
+            row=2, column=2, sticky="e", padx=5, pady=2
         )
         mode_combo = ttk.Combobox(
             helper_frame,
@@ -129,11 +147,11 @@ class MeshTallyView:
             textvariable=self.mode_var,
             width=10,
         )
-        mode_combo.grid(row=1, column=3, padx=5, pady=2)
+        mode_combo.grid(row=2, column=3, padx=5, pady=2)
 
         # Compute button on same row as delta and mode
         ttk.Button(helper_frame, text="Compute", command=self.compute_bins).grid(
-            row=1, column=4, columnspan=2, padx=5, pady=2
+            row=2, column=4, columnspan=2, padx=5, pady=2
         )
 
         for col in range(6):
@@ -331,6 +349,9 @@ class MeshTallyView:
         """Compute mesh bins using IMESH/JMESH/KMESH."""
 
         try:
+            xorigin = float(self.xorigin_var.get())
+            yorigin = float(self.yorigin_var.get())
+            zorigin = float(self.zorigin_var.get())
             imesh = float(self.imesh_var.get())
             jmesh = float(self.jmesh_var.get())
             kmesh = float(self.kmesh_var.get())
@@ -340,6 +361,9 @@ class MeshTallyView:
                 jmesh=jmesh,
                 kmesh=kmesh,
                 delta=delta,
+                xorigin=xorigin,
+                yorigin=yorigin,
+                zorigin=zorigin,
                 mode=self.mode_var.get(),
             )
         except Exception as e:  # pragma: no cover - GUI interaction

--- a/tests/test_mesh_bins_helper.py
+++ b/tests/test_mesh_bins_helper.py
@@ -20,6 +20,14 @@ def test_plan_mesh_from_mesh_uniform():
     assert edges["x"][-1] == 6.0
 
 
+def test_plan_mesh_from_mesh_with_origin():
+    result = plan_mesh_from_mesh(2.0, 2.0, 2.0, delta=1.0, xorigin=1.0, yorigin=1.0, zorigin=1.0)
+    ext = result["extents"]
+    assert ext["xmax"] == pytest.approx(3.0)
+    data = result["result"]
+    assert data["iints"] == 3
+
+
 def test_plan_mesh_from_counts_uniform():
     result = plan_mesh_from_counts(24, 16, 12, delta=0.25)
     ext = result["extents"]


### PR DESCRIPTION
## Summary
- allow specifying origin coordinates when planning mesh bins
- add origin inputs to mesh tally view UI
- update tests for origin-aware bin calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7a271f4832497b7eda6346cc9a9