### PR TITLE
Avoid auto plotting when adjusting slice

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -635,7 +635,8 @@ class MeshTallyView:
             self.slice_var.set(float(val))
         except Exception:
             return
-        self.plot_dose_slice()
+        # Don't automatically plot when adjusting the slider; only update the value
+        # so the user can choose when to render the slice via the dedicated button.
 
     def _update_slice_scale(self) -> None:
         """Recompute slider limits based on the selected axis."""
@@ -648,8 +649,9 @@ class MeshTallyView:
         min_val = float(self.msht_df[axis].min())
         max_val = float(self.msht_df[axis].max())
         self.slice_scale.configure(from_=min_val, to=max_val)
+        # Set the slider and variable to the minimum value without triggering a plot
         self.slice_scale.set(min_val)
-        self._on_slice_slider(min_val)
+        self.slice_var.set(min_val)
 
     def plot_dose_slice(self) -> None:
         """Render a 2-D slice of the dose map."""

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -482,15 +482,19 @@ def test_slice_slider_updates(monkeypatch):
     view._update_slice_scale()
     assert view.slice_scale.config["from_"] == 0.0
     assert view.slice_scale.config["to"] == 2.0
-    assert calls[-1] == 0.0
+    # Slider update should not trigger plotting automatically
+    assert calls == []
+    assert view.slice_var.get() == 0.0
 
     view.axis_var.set("z")
     view._update_slice_scale()
     assert view.slice_scale.config["to"] == 3.0
-    assert calls[-1] == 0.0
+    assert calls == []
+    assert view.slice_var.get() == 0.0
 
     view._on_slice_slider(1.5)
-    assert calls[-1] == 1.5
+    # Moving the slider should update the value without plotting
+    assert calls == []
     assert view.slice_var.get() == 1.5
 
 def test_load_stl_files(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- prevent dose-slice slider from automatically plotting on each move
- ensure slice scale updates don't trigger plotting and just set the value
- adjust tests for non-automatic plotting behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f01f48fc8324abe73d0a72c96a7b