### PR TITLE
Add slice coordinate titles to 2D dose plots

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -686,6 +686,7 @@ class MeshTallyView:
         x_axis, y_axis = axes[axis]
 
         fig, ax = plt.subplots()
+        ax.set_title(f"{axis.upper()} Slice at ~{int(round(nearest_val))}")
         cmap = plt.cm.jet
         quant_var = getattr(self, "dose_quantile_var", None)
         quant = (quant_var.get() / 100) if quant_var else 0.95

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -410,6 +410,9 @@ def test_plot_dose_slice(monkeypatch):
             def set_ylabel(self, label):
                 calls["ylabel"] = label
 
+            def set_title(self, title):
+                calls["title"] = title
+
         class DummyFig:
             def colorbar(self, sc, ax=None, label=""):
                 calls["colorbar"] = label
@@ -440,6 +443,8 @@ def test_plot_dose_slice(monkeypatch):
 
         view.plot_dose_slice()
         assert calls.get("norm") == expected_norm
+        expected_title = f"{view.axis_var.get().upper()} Slice at ~{int(round(view.slice_var.get()))}"
+        assert calls.get("title") == expected_title
         return calls
 
     # Log scaling


### PR DESCRIPTION
## Summary
- show axis and rounded slice value in 2D dose slice plot titles
- test that the plot title is set correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7f1a32e608324aa9d9eb9f636aa18