### PR TITLE
Add mesh subdivision parameter and re-probing of refined meshes

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -20,8 +20,17 @@ except Exception:  # pragma: no cover - vedo not available
 AXES_LABELS = {"xTitle": "x (cm)", "yTitle": "y (cm)", "zTitle": "z (cm)"}
 
 
-def load_stl_meshes(folderpath: str) -> tuple[list[Any], list[str]]:
-    """Load all STL files from *folderpath* as ``vedo`` meshes."""
+def load_stl_meshes(folderpath: str, subdivision: int = 0) -> tuple[list[Any], list[str]]:
+    """Load all STL files from *folderpath* as ``vedo`` meshes.
+
+    Parameters
+    ----------
+    folderpath:
+        Directory containing STL files to load.
+    subdivision:
+        Optional subdivision level applied to each loaded mesh. A value of
+        ``0`` leaves the mesh unchanged.
+    """
     if vedo is None:  # pragma: no cover - optional dependency
         return [], []
     files_in_folder = os.listdir(folderpath)
@@ -30,6 +39,8 @@ def load_stl_meshes(folderpath: str) -> tuple[list[Any], list[str]]:
     for file in stl_files:
         full_path = os.path.join(folderpath, file)
         mesh = vedo.Mesh(full_path).alpha(0.5).c("lightblue").wireframe(False)
+        if subdivision > 0:
+            mesh.triangulate().subdivide(subdivision)
         meshes.append(mesh)
     return meshes, stl_files
 
@@ -121,6 +132,9 @@ def show_dose_map(
             plt += mesh
         plt.show()
     else:
+        for mesh in meshes:
+            mesh.probe(vol)
+            mesh.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
         plt = show(vol, meshes, axes=axes, interactive=False)
         if hasattr(plt, "add_callback"):
             annotation = Text2D("", pos="top-left", bg="w", alpha=0.5)

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -56,6 +56,7 @@ def make_view(collect_callbacks: bool = False):
     view.slice_viewer_var = DummyVar(False)
     view.cmap_var = DummyVar("jet")
     view.log_scale_var = DummyVar(False)
+    view.subdivision_var = DummyVar(0)
     view.msht_path_var = DummyVar("MSHT file: None")
     view.stl_folder_var = DummyVar("STL folder: None")
     view.msht_path = None
@@ -575,7 +576,7 @@ def test_load_stl_files_nonblocking(tmp_path, monkeypatch):
     dummy_vedo = type("Vedo", (), {"Mesh": DummyMesh})
     monkeypatch.setattr(vedo_plotter, "vedo", dummy_vedo)
 
-    def fake_loader(folder):
+    def fake_loader(folder, level):
         time.sleep(0.2)
         return ([DummyMesh(str(tmp_path / "sample.stl"))], ["sample.stl"])
 

--- a/tests/test_vedo_plotter.py
+++ b/tests/test_vedo_plotter.py
@@ -1,0 +1,68 @@
+import types
+from pathlib import Path
+
+import pytest
+
+from mcnp.views import vedo_plotter
+
+
+def test_load_stl_meshes_subdivision(tmp_path, monkeypatch):
+    (tmp_path / "model.stl").write_text("", encoding="utf-8")
+
+    class DummyMesh:
+        def __init__(self, path):
+            self.path = path
+            self.subdivide_level = None
+            self.triangulated = False
+
+        def alpha(self, *a, **k):
+            return self
+
+        def c(self, *a, **k):
+            return self
+
+        def wireframe(self, *a, **k):
+            return self
+
+        def triangulate(self):
+            self.triangulated = True
+            return self
+
+        def subdivide(self, level):
+            self.subdivide_level = level
+            return self
+
+    dummy_vedo = types.SimpleNamespace(Mesh=DummyMesh)
+    monkeypatch.setattr(vedo_plotter, "vedo", dummy_vedo)
+
+    meshes, files = vedo_plotter.load_stl_meshes(str(tmp_path), subdivision=2)
+    assert files == ["model.stl"]
+    assert meshes[0].triangulated is True
+    assert meshes[0].subdivide_level == 2
+
+    meshes, _ = vedo_plotter.load_stl_meshes(str(tmp_path), subdivision=0)
+    assert meshes[0].subdivide_level is None
+
+
+def test_show_dose_map_probes(monkeypatch):
+    calls = {}
+
+    class DummyMesh:
+        def probe(self, vol):
+            calls["probed"] = calls.get("probed", 0) + 1
+            return self
+
+        def cmap(self, cmap_name, vmin=None, vmax=None):
+            calls["mesh_cmap"] = (cmap_name, vmin, vmax)
+            return self
+
+    def fake_show(*a, **k):
+        calls["show"] = True
+        return object()
+
+    monkeypatch.setattr(vedo_plotter, "show", fake_show)
+
+    vedo_plotter.show_dose_map(object(), [DummyMesh()], "jet", 0.0, 1.0, slice_viewer=False)
+    assert calls.get("probed") == 1
+    assert calls["mesh_cmap"][0] == "jet"
+    assert calls.get("show")


### PR DESCRIPTION
## Summary
- allow optional mesh subdivision when loading STL files
- re-probe meshes against volume before rendering
- expose GUI control and config persistence for subdivision level
- add tests for subdivision and re-probing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7f3dd5ba48324b7181d25024e08c5