### PR TITLE
Enforce Jet colormap and enlarge 3D slice scale

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -71,9 +71,6 @@ class MeshTallyView:
         # Toggle for logarithmic dose scaling
         self.log_scale_var = tk.BooleanVar(value=False)
 
-        # Colour map for 3-D dose rendering
-        self.cmap_var = tk.StringVar(value="jet")
-
         # Level of subdivision to apply to STL meshes
         self.subdivision_var = tk.IntVar(value=0)
 
@@ -234,17 +231,6 @@ class MeshTallyView:
             variable=self.dose_quantile_var,
             command=lambda v: self.dose_scale_value.config(text=f"{float(v):.0f}")
         ).pack(side="left", fill="x", expand=True, padx=5)
-
-        cmap_frame = ttk.Frame(settings_frame)
-        cmap_frame.pack(fill="x", padx=5, pady=5)
-        ttk.Label(cmap_frame, text="Colour map:").pack(side="left")
-        ttk.Combobox(
-            cmap_frame,
-            values=["jet", "Spectral", "viridis", "magma"],
-            state="readonly",
-            textvariable=self.cmap_var,
-            width=10,
-        ).pack(side="left", padx=5)
 
         # ------------------------------------------------------------------
         # 3-D plot controls
@@ -665,7 +651,7 @@ class MeshTallyView:
             vol, meshes, cmap_name, min_dose, max_dose = vp.build_volume(
                 df,
                 self.stl_meshes,
-                cmap_name=self.cmap_var.get(),
+                cmap_name="jet",
                 dose_quantile=dose_quantile,
                 log_scale=self.log_scale_var.get(),
                 warning_cb=Messagebox.show_warning,
@@ -749,8 +735,7 @@ class MeshTallyView:
 
         fig, ax = plt.subplots()
         ax.set_title(f"{axis.upper()} Slice at ~{int(round(nearest_val))}")
-        cmap_name = self.cmap_var.get() if hasattr(self, "cmap_var") else "jet"
-        cmap = plt.get_cmap(cmap_name)
+        cmap = plt.get_cmap("jet")
         quant_var = getattr(self, "dose_quantile_var", None)
         quant = (quant_var.get() / 100) if quant_var else 0.95
         max_dose = slice_df["dose"].quantile(quant)

--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -147,7 +147,7 @@ def build_volume(
 
     vol = Volume(grid, spacing=(dx, dy, dz), origin=(xs[0], ys[0], zs[0]))
     vol.cmap(cmap_name, vmin=min_dose, vmax=max_dose)
-    vol.add_scalarbar(title=bar_title, size=(200, 600), font_size=24)
+    vol.add_scalarbar(title=bar_title, size=(300, 900), font_size=36)
     if volume_sampling:
         sampled: list[Any] = []
         for mesh in stl_meshes:

--- a/tests/test_mesh_view.py
+++ b/tests/test_mesh_view.py
@@ -55,7 +55,6 @@ def make_view(collect_callbacks: bool = False):
     view.slice_var = DummyVar("0")
     view.slice_viewer_var = DummyVar(True)
     view.volume_sampling_var = DummyVar(False)
-    view.cmap_var = DummyVar("jet")
     view.log_scale_var = DummyVar(False)
     view.subdivision_var = DummyVar(0)
     view.msht_path_var = DummyVar("MSHT file: None")
@@ -198,8 +197,6 @@ def test_plot_dose_map(monkeypatch):
         {"x": [1.0, 2.0], "y": [1.0, 1.0], "z": [0.0, 0.0], "dose": [1.0, 4.0]}
     )
     view.stl_meshes = []
-    view.cmap_var.set("viridis")
-
     calls = {}
 
     class DummyVolume:
@@ -252,10 +249,10 @@ def test_plot_dose_map(monkeypatch):
     assert linear_calls["grid"][0][0][0] == pytest.approx(1.0)
     # Second value is clipped to the chosen max dose
     assert linear_calls["grid"][1][0][0] == pytest.approx(linear_calls["cmap"][2])
-    assert linear_calls["cmap"][0] == "viridis"
+    assert linear_calls["cmap"][0] == "jet"
     assert linear_calls["scalarbar"]["title"] == "Dose (µSv/h)"
-    assert linear_calls["scalarbar"]["size"] == (200, 600)
-    assert linear_calls["scalarbar"]["font_size"] == 24
+    assert linear_calls["scalarbar"]["size"] == (300, 900)
+    assert linear_calls["scalarbar"]["font_size"] == 36
     assert linear_calls["show_axes"] == mesh_view.AXES_LABELS
 
     # Log scaling assertions
@@ -318,7 +315,6 @@ def test_plot_dose_map_nonuniform_spacing(monkeypatch):
 def test_plot_dose_map_slice_viewer(monkeypatch):
     view = make_view()
     view.msht_df = pd.DataFrame({"x": [1.0], "y": [1.0], "z": [0.0], "dose": [1.0]})
-    view.cmap_var.set("magma")
     calls = {}
 
     class DummyVolume:
@@ -390,8 +386,8 @@ def test_plot_dose_map_slice_viewer(monkeypatch):
     view.plot_dose_map()
     assert calls["axes"] == mesh_view.AXES_LABELS
     assert calls["show"] is True
-    assert calls["vol_cmap"][0] == "magma"
-    assert calls["mesh_cmap"][0] == "magma"
+    assert calls["vol_cmap"][0] == "jet"
+    assert calls["mesh_cmap"][0] == "jet"
     assert calls.get("callback") == "MouseMove"
     assert calls.get("added") is True
     assert "plain_show" not in calls


### PR DESCRIPTION
## Summary
- Increase scalar bar size and font in 3D dose volume rendering for better readability
- Remove colormap selection and always use Jet for 3D dose maps and slice plots
- Update tests to reflect the fixed Jet colormap and larger scale

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c80b5b8cd88324a0a3174da0215083