### PR TITLE
Reset STL subdivision level on startup

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -411,7 +411,10 @@ class MeshTallyView:
                 if hasattr(self, "slice_var"):
                     self.slice_var.set(config.get("slice_value", ""))
                 if hasattr(self, "subdivision_var"):
-                    self.subdivision_var.set(config.get("mesh_subdivision", 0))
+                    # Always start new sessions without additional subdivision so
+                    # STL meshes are loaded in their original resolution unless
+                    # the user explicitly opts in after launch.
+                    self.subdivision_var.set(0)
             except Exception as e:  # pragma: no cover - disk issues
                 if app and hasattr(app, "log"):
                     app.log(f"Failed to load config: {e}", logging.ERROR)

--- a/tests/test_mesh_config.py
+++ b/tests/test_mesh_config.py
@@ -34,6 +34,7 @@ def create_mesh_view(app, mesh_view_module):
     mv.axis_var = DummyVar("y")
     mv.slice_var = DummyVar("0")
     mv.slice_viewer_var = DummyVar(True)
+    mv.subdivision_var = DummyVar(0)
     mv.msht_path = None
     mv.stl_folder = None
     mv.msht_path_var = DummyVar("MSHT file: None")
@@ -59,6 +60,7 @@ def test_mesh_view_config(tmp_path, monkeypatch):
     mv.axis_var.set("x")
     mv.slice_var.set("1")
     mv.slice_viewer_var.set(True)
+    mv.subdivision_var.set(2)
     mv.msht_path = "last.msht"
     mv.stl_folder = "stl_folder"
     mv.save_config()
@@ -72,6 +74,7 @@ def test_mesh_view_config(tmp_path, monkeypatch):
     assert data["slice_viewer"] is True
     assert data["slice_axis"] == "x"
     assert data["slice_value"] == "1"
+    assert data["mesh_subdivision"] == 2
 
     mv2 = create_mesh_view(app, mesh_view_module)
     mv2.load_config()
@@ -83,3 +86,4 @@ def test_mesh_view_config(tmp_path, monkeypatch):
     assert mv2.axis_var.get() == "x"
     assert mv2.slice_var.get() == "1"
     assert mv2.slice_viewer_var.get() is True
+    assert mv2.subdivision_var.get() == 0


### PR DESCRIPTION
## Summary
- always reset the mesh subdivision level to zero when loading configuration so each launch starts with the base STL resolution
- extend the mesh config test helpers to cover subdivision persistence and ensure the value resets on load

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c932195bb083248207511fdee9f8b5