### PR TITLE
Remove redundant absorbed dose calculation

### DIFF
--- a/src/mcnp/views/vedo_plotter.py
+++ b/src/mcnp/views/vedo_plotter.py
@@ -138,7 +138,7 @@ def _compute_mesh_statistics(
     voxel_volume: float,
     metadata: dict[str, Any],
 ) -> dict[str, float | int]:
-    """Calculate mean and mass-weighted dose statistics for *mesh*."""
+    """Calculate mean dose and mass-related statistics for *mesh*."""
 
     if not hasattr(mesh, "inside_points"):
         return {}
@@ -177,9 +177,6 @@ def _compute_mesh_statistics(
         total_mass = mass_per_voxel * voxel_doses.size
         stats["mass_per_voxel_g"] = float(mass_per_voxel)
         stats["total_mass_g"] = float(total_mass)
-        total_absorbed = float(np.sum(voxel_doses * mass_per_voxel))
-        if total_mass > 0.0:
-            stats["absorbed_dose_rate"] = total_absorbed / total_mass
 
     return stats
 
@@ -513,9 +510,6 @@ def show_dose_map(
                     mean_val = _format_number(stats.get("mean_dose_rate"))
                     if mean_val is not None:
                         stats_parts.append(f"Mean dose: {mean_val:.3g} µSv/h")
-                    absorbed_val = _format_number(stats.get("absorbed_dose_rate"))
-                    if absorbed_val is not None:
-                        stats_parts.append(f"Absorbed dose: {absorbed_val:.3g} µSv/h")
                     voxel_count = stats.get("voxel_count")
                     if isinstance(voxel_count, (int, np.integer)) and voxel_count > 0:
                         stats_parts.append(f"Voxels: {int(voxel_count)}")

--- a/tests/test_vedo_plotter.py
+++ b/tests/test_vedo_plotter.py
@@ -141,7 +141,6 @@ def test_show_dose_map_slice_viewer(monkeypatch):
                     "density": "0.997 g/cm^3",
                     "dose_statistics": {
                         "mean_dose_rate": 2.5,
-                        "absorbed_dose_rate": 2.5,
                         "voxel_count": 10,
                         "total_mass_g": 5.0,
                     },
@@ -213,7 +212,7 @@ def test_show_dose_map_slice_viewer(monkeypatch):
         calls["text"]
         == "Dose: 1.23 µSv/h @ (1, 2, 3)\n"
         "Object: Dummy Mesh | Material: Water (1) | Density: 0.997 g/cm^3\n"
-        "Mean dose: 2.5 µSv/h | Absorbed dose: 2.5 µSv/h | Voxels: 10 | Mass: 5 g"
+        "Mean dose: 2.5 µSv/h | Voxels: 10 | Mass: 5 g"
     )
 
     DummyPoint.value = 2.0
@@ -226,7 +225,7 @@ def test_show_dose_map_slice_viewer(monkeypatch):
         calls["text"]
         == "Result: 40 | Dose: 100 µSv/h | log10: 2 @ (4, 5, 6)\n"
         "Object: Dummy Mesh | Material: Cadmium (3) | Density: 8.65 g/cm^3\n"
-        "Mean dose: 2.5 µSv/h | Absorbed dose: 2.5 µSv/h | Voxels: 10 | Mass: 5 g"
+        "Mean dose: 2.5 µSv/h | Voxels: 10 | Mass: 5 g"
     )
 
 
@@ -346,7 +345,6 @@ def test_build_volume_mesh_statistics(monkeypatch):
     assert stats["mean_dose_rate"] == pytest.approx(2.0)
     assert stats["voxel_count"] == 3
     assert stats["total_mass_g"] == pytest.approx(6.0)
-    assert stats["absorbed_dose_rate"] == pytest.approx(2.0)
 
 
 def test_build_volume_metadata(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the absorbed/mass-weighted dose statistic because it duplicates the mean dose result
- update the dose map annotation and tests to reflect the streamlined statistics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96665a888832497c3ad54c1c91551