### PR TITLE
Correct helium-3 density metadata and molar mass

### DIFF
--- a/tests/test_vedo_plotter.py
+++ b/tests/test_vedo_plotter.py
@@ -1,8 +1,29 @@
+import math
 import types
 
 import pytest
 
 from mcnp.views import vedo_plotter
+
+
+def test_density_conversion_for_number_density():
+    metadata = {"material_name": "Helium-3", "material_id": 2}
+    expected = 3.016 / 6.022_140_76e23
+    result = vedo_plotter._density_to_g_per_cm3(1.0, "atoms/cm^3", metadata)
+    assert math.isclose(result, expected, rel_tol=1e-12)
+
+
+def test_extract_density_handles_atoms_unit():
+    metadata = {
+        "material_name": "Helium-3",
+        "material_id": 2,
+        "density_value": 2.5,
+        "density_unit": "atoms/cm^3",
+    }
+    expected = 2.5 * 3.016 / 6.022_140_76e23
+    assert math.isclose(
+        vedo_plotter._extract_density_in_g_cm3(metadata), expected, rel_tol=1e-12
+    )
 
 
 def test_load_stl_meshes_subdivision(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep the Helium-3 material entry in atoms/cm^3 with the corrected 4.925e-5 number density while relying on the Avogadro-based conversion path (molar mass updated to 3.016 g/mol)
- cover the new conversion path with unit tests for `_density_to_g_per_cm3` and `_extract_density_in_g_cm3`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96b0c6f508324822bdffdf028a4c1