### PR TITLE
Refactor view config persistence

### DIFF
--- a/src/mcnp/views/config_store.py
+++ b/src/mcnp/views/config_store.py
@@ -1,0 +1,32 @@
+"""Helpers for persisting view configuration data."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass(slots=True)
+class JsonConfigStore:
+    """Simple JSON-backed store for persisting configuration dictionaries."""
+
+    path: Path
+
+    def load(self) -> Dict[str, Any]:
+        """Return the JSON payload stored at :attr:`path` if it exists."""
+
+        if not self.path.exists():
+            return {}
+        with open(self.path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def merge(self, updates: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge ``updates`` into the existing JSON configuration."""
+
+        data = self.load()
+        data.update(updates)
+        with open(self.path, "w", encoding="utf-8") as handle:
+            json.dump(data, handle)
+        return data


### PR DESCRIPTION
## Summary
- add a reusable `JsonConfigStore` helper for reading and merging persisted view preferences
- wrap analysis view configuration in a dataclass and lazily load detector metadata to support test stubs
- use a `MeshConfigData` dataclass to consolidate mesh view save/load logic

## Testing
- pytest tests/test_analysis_config.py tests/test_mesh_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c981b0d1288324a667f03b4b8f36c3