### PR TITLE
Remove unused imports from mesh tally view

### DIFF
--- a/src/mcnp/views/mesh_view.py
+++ b/src/mcnp/views/mesh_view.py
@@ -8,11 +8,9 @@ from typing import Any, Mapping
 import threading
 
 import pandas as pd
-import numpy as np
 import matplotlib
 
 import os
-import sys
 
 try:  # Use TkAgg if available for interactive plots
     matplotlib.use("TkAgg")


### PR DESCRIPTION
## Summary
- remove unused numpy and sys imports from the mesh tally view module to quiet linters

## Testing
- pytest tests/test_mesh_view.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ae6dc78c8324a5b6808d5bcdc82b