### PR TITLE
Load material metadata from CSV resource

### DIFF
--- a/src/mcnp/views/mesh/materials.csv
+++ b/src/mcnp/views/mesh/materials.csv
@@ -1,0 +1,10 @@
+material_id,material_name,density_value,density_unit,molar_mass_g_per_mol
+1,Water,0.997,g/cm^3,
+2,Helium-3,4.925e-5,atoms/cm^3,3.016
+3,Cadmium,8.65,g/cm^3,
+4,Polythene,0.96,g/cm^3,
+5,Concrete,2.4,g/cm^3,
+6,Graphite,1.7,g/cm^3,
+7,Borated Polythene,1.04,g/cm^3,
+8,Steel,7.872,g/cm^3,
+9,Wood,0.650,g/cm^3,

--- a/tests/test_vedo_plotter.py
+++ b/tests/test_vedo_plotter.py
@@ -7,6 +7,15 @@ import pytest
 from mcnp.views import vedo_plotter
 
 
+def test_material_properties_loaded_from_csv():
+    assert vedo_plotter.MATERIAL_PROPERTIES[1] == ("Water", "0.997 g/cm^3")
+    assert vedo_plotter.MATERIAL_PROPERTIES[2] == (
+        "Helium-3",
+        "4.925e-5 atoms/cm^3",
+    )
+    assert math.isclose(vedo_plotter.MOLAR_MASS_G_PER_MOL["helium-3"], 3.016)
+
+
 def _dose_bounds(df: pd.DataFrame, quantile: float) -> tuple[float, float]:
     max_dose = float(df["dose"].quantile(quantile))
     if not pd.notna(max_dose) or max_dose <= 0.0:
@@ -19,7 +28,7 @@ def _dose_bounds(df: pd.DataFrame, quantile: float) -> tuple[float, float]:
 
 
 def test_density_conversion_for_number_density():
-    metadata = {"material_name": "Helium-3", "material_id": 2}
+    metadata = {"material_id": 2}
     expected = 3.016 / 6.022_140_76e23
     result = vedo_plotter._density_to_g_per_cm3(1.0, "atoms/cm^3", metadata)
     assert math.isclose(result, expected, rel_tol=1e-12)


### PR DESCRIPTION
## Summary
- add a `materials.csv` resource so mesh materials can be updated without code changes
- load material names, densities, and molar masses from the CSV when building lookup tables
- extend tests to cover CSV-driven lookups and atomic-density conversions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe4eeb2788324b28a309619c8559c