### PR TITLE
Add transparency support for vedo mesh materials

### DIFF
--- a/src/mcnp/views/mesh/materials.csv
+++ b/src/mcnp/views/mesh/materials.csv
@@ -1,10 +1,10 @@
-material_id,material_name,density_value,density_unit,molar_mass_g_per_mol
-1,Water,0.997,g/cm^3,
-2,Helium-3,4.925e-5,atoms/cm^3,3.016
-3,Cadmium,8.65,g/cm^3,
-4,Polythene,0.96,g/cm^3,
-5,Concrete,2.4,g/cm^3,
-6,Graphite,1.7,g/cm^3,
-7,Borated Polythene,1.04,g/cm^3,
-8,Steel,7.872,g/cm^3,
-9,Wood,0.650,g/cm^3,
+material_id,material_name,density_value,density_unit,molar_mass_g_per_mol,transparent
+1,Water,0.997,g/cm^3,,y
+2,Helium-3,4.925e-5,atoms/cm^3,3.016,y
+3,Cadmium,8.65,g/cm^3,,n
+4,Polythene,0.96,g/cm^3,,n
+5,Concrete,2.4,g/cm^3,,n
+6,Graphite,1.7,g/cm^3,,n
+7,Borated Polythene,1.04,g/cm^3,,n
+8,Steel,7.872,g/cm^3,,n
+9,Wood,0.650,g/cm^3,,n


### PR DESCRIPTION
## Summary
- add a transparency column to the materials resource list
- expose transparency metadata when loading STL meshes and apply reduced alpha for flagged materials
- update vedo plotter tests to cover the new material structure and transparency behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbee2f5f8c832493a206ee55a0dc09