### PR TITLE
Force Agg backend for threaded He-3 plotting

### DIFF
--- a/src/mcnp/he3_plotter/analysis.py
+++ b/src/mcnp/he3_plotter/analysis.py
@@ -5,7 +5,14 @@ import pandas as pd
 import numpy as np
 import matplotlib
 
-matplotlib.use("Agg")
+# Force the non-interactive Agg backend so plots can be generated safely when
+# this module is executed from a background thread.  The GUI imports elsewhere
+# in the application may have already selected an interactive backend (e.g.
+# ``TkAgg``), and attempting to create figures from a worker thread with that
+# backend triggers ``UserWarning: Starting a Matplotlib GUI outside of the main
+# thread will likely fail``.  Using ``force=True`` ensures we override any
+# previously chosen backend without relying on global import order.
+matplotlib.use("Agg", force=True)
 import matplotlib.pyplot as plt
 
 from .io_utils import get_output_path, select_file

--- a/src/mcnp/he3_plotter/plots.py
+++ b/src/mcnp/he3_plotter/plots.py
@@ -2,7 +2,10 @@ import os
 import logging
 import matplotlib
 
-matplotlib.use("Agg")
+# See ``analysis.py`` for details.  The plotting utilities may be invoked from
+# background worker threads, so we force the Agg backend to avoid interactive
+# GUI backends being reused.
+matplotlib.use("Agg", force=True)
 import matplotlib.pyplot as plt
 
 from .io_utils import get_output_path


### PR DESCRIPTION
## Summary
- force the Matplotlib Agg backend when running the He-3 analysis helpers
- ensure plotting utilities override any interactive backend selected by the GUI to avoid thread warnings

## Testing
- pytest *(fails: tests/test_mesh_view.py::test_plot_dose_map, tests/test_vedo_plotter.py::test_show_dose_map_slice_viewer)*

------
https://chatgpt.com/codex/tasks/task_e_68d6832db3ac8324ac52fee64fdeafdc