### PR TITLE
Prevent redundant TkAgg backend switching

### DIFF
--- a/src/mcnp/views/analysis/__init__.py
+++ b/src/mcnp/views/analysis/__init__.py
@@ -424,13 +424,19 @@ class AnalysisView:
             )
             return
         try:
-            plt.switch_backend("TkAgg")
-        except Exception as exc:  # pragma: no cover - backend switching errors
-            self.app.log(
-                f"Unable to switch Matplotlib backend to TkAgg: {exc}",
-                logging.WARNING,
-            )
-            return
+            current_backend = str(plt.get_backend()).lower()
+        except Exception:  # pragma: no cover - backend query failures
+            current_backend = ""
+
+        if current_backend != "tkagg":
+            try:
+                plt.switch_backend("TkAgg")
+            except Exception as exc:  # pragma: no cover - backend switching errors
+                self.app.log(
+                    f"Unable to switch Matplotlib backend to TkAgg: {exc}",
+                    logging.WARNING,
+                )
+                return
 
         if result.analysis_type == AnalysisType.EFFICIENCY_NEUTRON_RATES:
             self._plot_efficiency_results(data, plt)


### PR DESCRIPTION
## Summary
- avoid switching Matplotlib to TkAgg when it is already active to prevent UI resets
- gracefully handle failures when querying the active backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6905d5b008324886811e35f1ec199