### PR TITLE
Handle .out MCNP outputs in thickness comparison

### DIFF
--- a/src/mcnp/he3_plotter/analysis.py
+++ b/src/mcnp/he3_plotter/analysis.py
@@ -220,9 +220,13 @@ def parse_thickness_from_filename(filename):
     ``float``; returns ``None`` if no thickness token is found.
     """
     base = os.path.basename(filename)
-    # Look for a number before optional 'cm' and a trailing 'o' or '.o'
-    # Example matches: _10o, _10cmo, _10cm.o, 10cmo, 2_5cmo
-    m = re.search(r"(\d+(?:[._]\d+)?)\s*(?:cm)?(?:\.o|o)$", base, re.IGNORECASE)
+    # Look for a number before optional 'cm' and a trailing output extension
+    # Example matches: _10o, _10cmo, _10cm.o, _10cm.out, 10cmo, 2_5cmo
+    m = re.search(
+        r"(\d+(?:[._]\d+)?)\s*(?:cm)?(?:\.o|o|\.out|out)$",
+        base,
+        re.IGNORECASE,
+    )
     if not m:
         return None
     token = m.group(1).replace("_", ".")
@@ -343,8 +347,8 @@ def run_analysis_type_2(
     for folder_path, label in zip(folder_paths, labels):
         results = []
         for filename in os.listdir(folder_path):
-            # Accept both 'o' and '.o' endings, case-insensitively
-            if not filename.lower().endswith("o"):
+            # Accept common MCNP output extensions like '.o' and '.out'
+            if not filename.lower().endswith(("o", "out")):
                 continue
             file_path = os.path.join(folder_path, filename)
             if not os.path.isfile(file_path):

--- a/tests/test_he3_plotter.py
+++ b/tests/test_he3_plotter.py
@@ -26,6 +26,7 @@ def test_li6i_detector_geometry():
 def test_parse_thickness_from_filename_handles_optional_cm():
     assert parse_thickness_from_filename("example_10cmo") == 10
     assert parse_thickness_from_filename("example_10o") == 10
+    assert parse_thickness_from_filename("example_10cm.out") == 10
     assert parse_thickness_from_filename("example_o") is None
 
 def test_process_simulation_file_no_tally():
@@ -127,6 +128,7 @@ def test_run_analysis_type_2_without_lab_data(tmp_path):
         "1tally    24\nenergy value error\n0.1 1.0 0.05\n0.2 2.0 0.1\ntotal\n"
     )
     (folder / "example_1o").write_text(content)
+    (folder / "example_2cm.out").write_text(content)
     run_analysis_type_2(
         str(folder), lab_data_path=None, area=1.0, volume=1.0, neutron_yield=1.0
     )
@@ -143,6 +145,7 @@ def test_run_analysis_type_2_without_lab_data(tmp_path):
         "dataset",
     ]
     assert set(df["dataset"]) == {"sim"}
+    assert set(df["thickness"]) == {1, 2}
 
 
 def test_run_analysis_type_2_multiple_folders_without_lab_data(tmp_path):


### PR DESCRIPTION
## Summary
- allow the thickness parser to recognise MCNP outputs saved with a .out extension
- update the folder scan to include .out files when gathering simulated thickness data
- cover the new behaviour with unit tests for parsing and aggregation

## Testing
- pytest tests/test_he3_plotter.py

------
https://chatgpt.com/codex/tasks/task_e_68d6941e633c8324965503f1fd983f81