### PR TITLE
Ensure STL loading runs on Tk main thread

### DIFF
--- a/docs/help_text.txt
+++ b/docs/help_text.txt
@@ -92,6 +92,7 @@ Use the **Mesh Tally** tab to plan mesh tally bin structures, inspect `MSHT` tal
 • Tweak **Display Settings** to pick a percentile-based dose scale, switch to a logarithmic colour map, or disable scaling entirely.
 • Use **Slice Viewer** to step through the mesh interactively, and enable **Volume sampling** to fill voxels when exploring sparse meshes.
 • Load STL geometry via **Load STL Files** to overlay CAD models; adjust the subdivision level and export processed meshes with **Save STL Files**.
+  STL meshes now load on the main Tkinter thread so the VTK-backed rendering remains stable; the progress dialog keeps the interface responsive while files are processed.
 • If mesh coordinates are not evenly spaced, a warning is shown and the first
   spacing value is used for the 3-D volume.
 • For 2-D dose slices choose an axis and slice value (or drag the slider) before clicking **Plot 2D Dose Slice**.


### PR DESCRIPTION
## Summary
- remove the background thread used for STL imports and schedule the VTK work on the Tk main loop instead
- guard repeated invocations with a new `_stl_loading` flag and keep the progress dialog/button state in sync when the load completes
- refresh the mesh view tests and user help to reflect the main-thread STL loading behaviour

## Testing
- pytest tests/test_mesh_view.py::test_load_stl_files tests/test_mesh_view.py::test_load_stl_files_runs_on_main_thread tests/test_mesh_view.py::test_load_stl_disables_button_and_prevents_overlap

------
https://chatgpt.com/codex/tasks/task_e_68d6a1c65a34832484e59898a37bb012