### PR TITLE
Simplify glTF export interaction

### DIFF
--- a/src/mcnp/views/mesh/__init__.py
+++ b/src/mcnp/views/mesh/__init__.py
@@ -52,8 +52,6 @@ class MeshConfigData:
     dose_scale_enabled: bool | None = None
     dose_scale_quantile: float | None = None
     log_scale: bool | None = None
-    export_gltf: bool = False
-    gltf_path: str | None = None
     _present: set[str] = field(default_factory=set, repr=False)
 
     def to_dict(self) -> dict[str, Any]:
@@ -81,8 +79,6 @@ class MeshConfigData:
             value = getattr(self, key)
             if key in self._present or value is not None:
                 data[key] = value
-        data["export_gltf"] = bool(self.export_gltf)
-        data["gltf_path"] = self.gltf_path
         return data
 
     @classmethod
@@ -150,10 +146,6 @@ class MeshConfigData:
             present.add("log_scale")
             log_scale = _get_bool(view.log_scale_var, False)
 
-        export_gltf = False
-        if hasattr(view, "export_gltf_var"):
-            export_gltf = _get_bool(view.export_gltf_var, False)
-
         return cls(
             sources={label: var.get() for label, var in view.source_vars.items()},
             custom_enabled=view.custom_var.get(),
@@ -168,8 +160,6 @@ class MeshConfigData:
             dose_scale_enabled=dose_scale_enabled,
             dose_scale_quantile=dose_scale_quantile,
             log_scale=log_scale,
-            export_gltf=export_gltf,
-            gltf_path=getattr(view, "gltf_path", None),
             _present=present,
         )
 
@@ -192,8 +182,6 @@ class MeshConfigData:
             dose_scale_enabled=data.get("dose_scale_enabled"),
             dose_scale_quantile=data.get("dose_scale_quantile"),
             log_scale=data.get("log_scale"),
-            export_gltf=bool(data.get("export_gltf", False)),
-            gltf_path=data.get("gltf_path"),
         )
 
     def apply_to_view(self, view: "MeshTallyView") -> None:
@@ -249,11 +237,6 @@ class MeshConfigData:
         if hasattr(view, "log_scale_var"):
             value = self.log_scale if self.log_scale is not None else False
             view.log_scale_var.set(value)
-
-        if hasattr(view, "export_gltf_var"):
-            view.export_gltf_var.set(bool(self.export_gltf))
-        if hasattr(view, "_set_gltf_path"):
-            view._set_gltf_path(self.gltf_path)
 
         if hasattr(view, "dose_scale"):
             view._update_dose_scale_state()
@@ -314,12 +297,6 @@ class MeshTallyView:
         # Toggle for volume sampling vs surface sampling
         self.volume_sampling_var = tk.BooleanVar(value=False)
 
-        # Optional glTF export configuration
-        self.export_gltf_var = tk.BooleanVar(value=False)
-        self.export_gltf_var.trace_add("write", lambda *_: self.save_config())
-        self.gltf_path_var = tk.StringVar(value="glTF file: None")
-        self.gltf_path: str | None = None
-
         self.msht_df: pd.DataFrame | None = None
         self.msht_path: str | None = None
         self._stl_service = StlMeshService(vp)
@@ -370,19 +347,10 @@ class MeshTallyView:
 
         return self.stl_service.stl_files
 
-    def _set_gltf_path(self, path: str | None) -> None:
-        """Update the stored glTF export path and associated label."""
-
-        self.gltf_path = path
-        if path:
-            self.gltf_path_var.set(f"glTF file: {path}")
-        else:
-            self.gltf_path_var.set("glTF file: None")
-
     def select_gltf_path(self) -> str | None:
         """Prompt the user to choose a glTF export destination."""
 
-        initial_path = self.gltf_path or os.path.join(os.path.expanduser("~"), "scene.gltf")
+        initial_path = os.path.join(os.path.expanduser("~"), "scene.gltf")
         initial_dir = os.path.dirname(initial_path) if initial_path else os.getcwd()
         initial_file = os.path.basename(initial_path) if initial_path else "scene.gltf"
 
@@ -393,11 +361,7 @@ class MeshTallyView:
             initialdir=initial_dir,
             initialfile=initial_file,
         )
-        if filename:
-            self._set_gltf_path(filename)
-            self.save_config()
-            return filename
-        return None
+        return filename or None
 
     # ------------------------------------------------------------------
     def build(self) -> None:
@@ -605,25 +569,11 @@ class MeshTallyView:
             text="Volume sampling",
             variable=self.volume_sampling_var,
         ).pack(side="left", padx=5)
-        ttk.Checkbutton(
+        ttk.Button(
             button_frame,
             text="Export glTF",
-            variable=self.export_gltf_var,
-        ).pack(side="left", padx=5)
-        ttk.Button(
-            button_frame,
-            text="Export glTF Now",
             command=self.export_gltf,
         ).pack(side="left", padx=5)
-        ttk.Button(
-            button_frame,
-            text="Choose glTF Path",
-            command=self.select_gltf_path,
-        ).pack(side="left", padx=5)
-
-        ttk.Label(plot3d_frame, textvariable=self.gltf_path_var, wraplength=600).pack(
-            fill="x", padx=5
-        )
 
     def _build_slice_controls(self, parent: ttk.LabelFrame) -> None:
         slice_frame = ttk.LabelFrame(parent, text="2D Slice")
@@ -1088,28 +1038,10 @@ class MeshTallyView:
             Messagebox.show_error("Dose Map Error", "Vedo library not available")
             return
 
-        export_enabled = export_only
-        export_var = getattr(self, "export_gltf_var", None)
-        if not export_only and export_var is not None:
-            try:
-                export_enabled = bool(export_var.get())
-            except Exception:  # pragma: no cover - Tk variable access issues
-                export_enabled = False
-
-        if export_enabled:
-            selected_path = export_path or getattr(self, "gltf_path", None)
-            if not selected_path:
-                selected_path = self.select_gltf_path()
-            if not selected_path:
-                if export_only:
-                    return
-                export_enabled = False
-                try:
-                    export_var.set(False)
-                except Exception:  # pragma: no cover - Tk variable access issues
-                    pass
-            else:
-                export_path = selected_path
+        if export_only and not export_path:
+            export_path = self.select_gltf_path()
+            if not export_path:
+                return
 
         stl_meshes = self.stl_service.get_base_meshes()
 
@@ -1149,12 +1081,11 @@ class MeshTallyView:
             "volume_sampling": self.volume_sampling_var.get(),
             "axes": AXES_LABELS,
         }
-        if export_enabled and export_path:
+        if export_path:
             kwargs["export_path"] = export_path
             if export_only:
                 kwargs["show_window"] = False
-
-        if export_only and "show_window" not in kwargs:
+        elif export_only:
             kwargs["show_window"] = False
 
         try:
@@ -1185,9 +1116,7 @@ class MeshTallyView:
     def export_gltf(self) -> None:
         """Export the current dose plot to a glTF file without showing the plot."""
 
-        path = self.gltf_path
-        if not path:
-            path = self.select_gltf_path()
+        path = self.select_gltf_path()
         if not path:
             return
         self.plot_dose_map(export_only=True, export_path=path)


### PR DESCRIPTION
## Summary
- remove the glTF export checkbox, path selector, and stored label from the mesh view
- always prompt for a destination when exporting glTF and drop persisted glTF settings
- simplify mesh configuration handling to reflect the streamlined export flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da543eac988324b4cdf281f0c19c87