### PR TITLE
Ensure prompt skips files without neutron tallies

### DIFF
--- a/src/mcnp/he3_plotter/analysis.py
+++ b/src/mcnp/he3_plotter/analysis.py
@@ -275,9 +275,15 @@ def prompt_for_valid_file(title="Select MCNP Output File"):
             logger.warning("No file selected. Please try again.")
             continue
         result = read_tally_blocks_to_df(file_path)
-        if result is not None:
+        if result is None:
+            logger.warning(
+                "Invalid file selected. No tally data found. Please select another file."
+            )
+            continue
+        df_neutron, _ = result
+        if df_neutron is not None and not df_neutron.empty:
             return file_path, result
-        logger.error(
+        logger.warning(
             "Invalid file selected. No tally data found. Please select another file."
         )
 


### PR DESCRIPTION
## Summary
- require `prompt_for_valid_file` to reject selections when the neutron tally data frame is empty and continue prompting
- add a regression test that exercises the selection flow when the first file lacks neutron tallies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da65ede48c8324b05669e17e587292