### PR TITLE
Respect MCNP_BASE_DIR precedence when resolving executable

### DIFF
--- a/src/mcnp/run_packages.py
+++ b/src/mcnp/run_packages.py
@@ -61,7 +61,11 @@ def get_mcnp_executable() -> Path:
     configuration files after import time are respected.
     """
     settings = load_settings()
-    root = os.getenv("MY_MCNP") or settings.get("MY_MCNP_PATH")
+    root = (
+        os.getenv("MCNP_BASE_DIR")
+        or os.getenv("MY_MCNP")
+        or settings.get("MY_MCNP_PATH")
+    )
     if root:
         return Path(root).expanduser() / "MCNP_CODE" / "bin" / "mcnp6"
     return Path("/nonexistent/MCNP_CODE/bin/mcnp6")

--- a/tests/test_run_packages.py
+++ b/tests/test_run_packages.py
@@ -90,3 +90,15 @@ def test_run_mesh_tally_missing_executable_logs_error(monkeypatch, tmp_path, cap
     with caplog.at_level(logging.ERROR):
         run_packages.run_mesh_tally(runtpe)
     assert "MCNP executable not found" in caplog.text
+
+
+def test_get_mcnp_executable_prefers_base_dir_env(monkeypatch, tmp_path):
+    env_base = tmp_path / "env"
+    monkeypatch.setenv("MCNP_BASE_DIR", str(env_base))
+    monkeypatch.setenv("MY_MCNP", str(tmp_path / "my_mcnp"))
+    monkeypatch.setattr(run_packages, "load_settings", lambda: {"MY_MCNP_PATH": str(tmp_path / "settings")})
+
+    executable = run_packages.get_mcnp_executable()
+
+    expected = env_base / "MCNP_CODE" / "bin" / "mcnp6"
+    assert executable == expected


### PR DESCRIPTION
## Summary
- ensure `get_mcnp_executable` consults `MCNP_BASE_DIR` before `MY_MCNP`
- add a regression test covering environment precedence when resolving the MCNP executable

## Testing
- pytest tests/test_run_packages.py::test_get_mcnp_executable_prefers_base_dir_env


------
https://chatgpt.com/codex/tasks/task_e_68da69a8ed0c8324946c69d0734cf338