### PR TITLE
Fix GUI clearing when showing thickness comparison plot

### DIFF
--- a/src/mcnp/he3_plotter/plots.py
+++ b/src/mcnp/he3_plotter/plots.py
@@ -1,11 +1,5 @@
 import os
 import logging
-import matplotlib
-
-# See ``analysis.py`` for details.  The plotting utilities may be invoked from
-# background worker threads, so we force the Agg backend to avoid interactive
-# GUI backends being reused.
-matplotlib.use("Agg", force=True)
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 


### PR DESCRIPTION
## Summary
- stop forcing the Matplotlib Agg backend in the analysis helpers so the Tk GUI keeps its interactive backend
- refactor analysis plotting routines to build figures with FigureCanvasAgg, keeping background-thread rendering headless-safe

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe1e5b5108324a484def8e6e4535f