### PR TITLE
Ensure neutron rate plot differentiates incident and detected colors

### DIFF
--- a/src/mcnp/views/analysis/__init__.py
+++ b/src/mcnp/views/analysis/__init__.py
@@ -457,14 +457,15 @@ class AnalysisView:
         fig1, ax1 = plt.subplots(figsize=(10, 6))
         if "surface" in df.columns:
             for i, (surface, grp) in enumerate(df.groupby("surface")):
-                color = f"C{i}"
+                incident_color = f"C{2 * i}"
+                detected_color = f"C{2 * i + 1}"
                 ax1.errorbar(
                     grp["energy"],
                     grp["rate_incident"],
                     yerr=grp["rate_incident_err"],
                     label=f"Incident Rate (Surface {surface})",
                     fmt="o-",
-                    color=color,
+                    color=incident_color,
                     markersize=3,
                     capsize=2,
                 )
@@ -474,7 +475,7 @@ class AnalysisView:
                     yerr=grp["rate_detected_err"],
                     label=f"Detected Rate (Surface {surface})",
                     fmt="s-",
-                    color=color,
+                    color=detected_color,
                     markersize=3,
                     capsize=2,
                 )
@@ -485,6 +486,7 @@ class AnalysisView:
                 yerr=df["rate_incident_err"],
                 label="Incident Rate",
                 fmt="o-",
+                color="C0",
                 markersize=3,
                 capsize=2,
             )
@@ -494,6 +496,7 @@ class AnalysisView:
                 yerr=df["rate_detected_err"],
                 label="Detected Rate",
                 fmt="s-",
+                color="C1",
                 markersize=3,
                 capsize=2,
             )


### PR DESCRIPTION
## Summary
- assign distinct colors to incident and detected neutron rate series in the analysis plot
- ensure single-surface plots also use separate default colors for incident and detected curves

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd146fc10c8324b2d87f10aa867981