### PR TITLE
Prevent clipping in library ratio plots by increasing layout/savefig padding

### DIFF
--- a/src/mcnp/he3_plotter/analysis.py
+++ b/src/mcnp/he3_plotter/analysis.py
@@ -806,7 +806,7 @@ def plot_library_ratio_pairs(pairs_df, base_dir, tag, kind):
         ax.tick_params(labelsize=config.tick_label_fontsize)
         if config.show_legend:
             ax.legend(fontsize=config.legend_fontsize)
-        fig.tight_layout()
+        fig.tight_layout(pad=1.6)
 
         safe_configuration = re.sub(r"[^A-Za-z0-9._ -]+", "_", configuration_str)
         save_path = get_output_path(
@@ -815,7 +815,7 @@ def plot_library_ratio_pairs(pairs_df, base_dir, tag, kind):
             f"{safe_configuration} library ratio {kind}",
             subfolder="plots",
         )
-        fig.savefig(save_path, bbox_inches="tight")
+        fig.savefig(save_path, bbox_inches="tight", pad_inches=0.2)
         fig.clf()
         logger.info(f"Saved: {save_path}")
         plot_paths.append(save_path)


### PR DESCRIPTION
### Motivation
- Prevent the library ratio plot from clipping the y-axis title and the metrics box on the right by increasing layout/savefig padding.

### Description
- Modify `src/mcnp/he3_plotter/analysis.py` to use `fig.tight_layout(pad=1.6)` and `fig.savefig(..., bbox_inches="tight", pad_inches=0.2)` to add extra interior and save-time padding.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b6b17fd08324a2d9f8ada12d769d)